### PR TITLE
Introduce new env variable to allow cache keys with similar prefixes

### DIFF
--- a/cache/restorer.go
+++ b/cache/restorer.go
@@ -68,7 +68,11 @@ func (r restorer) Restore(dsts []string) error {
 			}
 
 			for _, e := range entries {
-				dsts = append(dsts, strings.TrimPrefix(e.Path, prefix))
+				if r.enableCacheKeySeparator {
+					dsts = append(dsts, strings.TrimPrefix(e.Path, prefix))
+				} else {
+					dsts = append(dsts, strings.TrimPrefix(e.Path, prefix+getSeparator()))
+				}
 			}
 		} else if err != common.ErrNotImplemented {
 			return err


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Thank you for your pull request. Please provide a description above and review
the requirements below.

**BUG FIXES AND NEW FEATURES SHOULD INCLUDE TESTS.**

Contributors guide: ./CONTRIBUTING.md
Code of conduct: ./CODE_OF_CONDUCT.md
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.

Fixes #

## Proposed Changes
<!-- Please briefly list the changes you made here. -->

- Add a new var to turn on this feature, where cache keys with similar prefix are separated using '/'
- By default its off, two cache keys can't be having prefix that is a substring of other cache key

### Description

<!-- Please explain the changes you made here. -->

### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
