### PR TITLE
[CI-12672]: added support for dotnet caching

### DIFF
--- a/internal/plugin/autodetect/auto_detect_util.go
+++ b/internal/plugin/autodetect/auto_detect_util.go
@@ -46,6 +46,11 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 			tool:         "golang",
 			preparer:     newGoPreparer(),
 		},
+		{
+			globToDetect: "*.csproj",
+			tool:         "dotnet",
+			preparer:     newDotnetPreparer(),
+		},
 	}
 
 	var directoriesToCache []string

--- a/internal/plugin/autodetect/prepare_dotnet.go
+++ b/internal/plugin/autodetect/prepare_dotnet.go
@@ -1,0 +1,113 @@
+package autodetect
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type Configuration struct {
+	XMLName xml.Name `xml:"configuration"`
+	Config  *Config  `xml:"config"`
+}
+
+type Config struct {
+	Add []Add `xml:"add"`
+}
+
+type Add struct {
+	Key   string `xml:"key,attr"`
+	Value string `xml:"value,attr"`
+}
+
+type dotnetPreparer struct{}
+
+func newDotnetPreparer() *dotnetPreparer {
+	return &dotnetPreparer{}
+}
+
+func (*dotnetPreparer) PrepareRepo(dir string) (string, error) {
+	pathToCache := filepath.Join(dir, ".nuget", "packages")
+	configPath := filepath.Join(dir, "nuget.config")
+	updateConfig := false
+	foundGlobalPackagesFolder := false
+
+	//file not exists
+	if _, err := os.Stat(configPath); errors.Is(err, os.ErrNotExist) {
+		f, err := os.Create(configPath)
+		if err != nil {
+			return "", err
+		}
+		configuration := Configuration{}
+		marshalledConfig, err := xml.MarshalIndent(configuration, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		os.WriteFile(configPath, marshalledConfig, 0644)
+		f.Close()
+	}
+
+	//file exists
+	file, err := os.Open(configPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %w", err)
+	}
+	defer file.Close()
+
+	// Read the file contents
+	data, err := io.ReadAll(file)
+	if err != nil {
+		return "", fmt.Errorf("failed to read file: %w", err)
+	}
+
+	// Parse the XML
+	var configuration Configuration
+	err = xml.Unmarshal(data, &configuration)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse XML: %w", err)
+	}
+
+	if configuration.Config == nil {
+		configuration.Config = &Config{}
+		updateConfig = true
+	}
+
+	for _, add := range configuration.Config.Add {
+		if add.Key == "globalPackagesFolder" {
+			if add.Value != pathToCache && add.Value != filepath.Join(".nuget", "packages") {
+				return "", fmt.Errorf("unsupported custom globalPackagesFolder value")
+			}
+			foundGlobalPackagesFolder = true
+		}
+	}
+
+	if !foundGlobalPackagesFolder {
+		// Add the globalPackagesFolder value
+		configuration.Config.Add = append(configuration.Config.Add, Add{
+			Key:   "globalPackagesFolder",
+			Value: pathToCache,
+		})
+		updateConfig = true
+	}
+
+	if updateConfig {
+		writeConfigurationToFile(configPath, configuration)
+	}
+
+	return pathToCache, nil
+}
+
+func writeConfigurationToFile(filePath string, config Configuration) error {
+	updatedData, err := xml.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated nuget.config: %w", err)
+	}
+	err = os.WriteFile(filePath, updatedData, 0644)
+	if err != nil {
+		return fmt.Errorf("failed to write updated nuget.config: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.

Fixes #

## Proposed Changes
Adding support for caching dotnet packages

### Description



### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
