### PR TITLE
fix: [CI-15249]: fixed bug where restore step failed on windows

### DIFF
--- a/archive/tar/tar.go
+++ b/archive/tar/tar.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/go-kit/kit/log"
@@ -92,7 +91,7 @@ func writeToArchive(tw *tar.Writer, root string, skipSymlinks bool, written *int
 		}
 
 		var name string
-		if strings.HasPrefix(path, getRootPathPrefix()) {
+		if filepath.IsAbs(path) {
 			name, err = filepath.Abs(path)
 		} else if isRelativePath {
 			name = path
@@ -146,14 +145,6 @@ func relative(parent string, path string) (string, error) {
 	return strings.TrimPrefix(filepath.Join(rel, name), "/"), nil
 }
 
-func getRootPathPrefix() string {
-	if runtime.GOOS == "windows" {
-		return `C:\`
-	}
-
-	return "/"
-}
-
 func createSymlinkHeader(fi os.FileInfo, path string) (*tar.Header, error) {
 	lnk, err := os.Readlink(path)
 	if err != nil {
@@ -204,7 +195,7 @@ func (a *Archive) Extract(dst string, r io.Reader) (int64, error) {
 		}
 
 		var target string
-		if dst == h.Name || strings.HasPrefix(h.Name, getRootPathPrefix()) {
+		if dst == h.Name || filepath.IsAbs(h.Name) {
 			target = h.Name
 		} else {
 			name, err := relative(dst, h.Name)


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Thank you for your pull request. Please provide a description above and review
the requirements below.

**BUG FIXES AND NEW FEATURES SHOULD INCLUDE TESTS.**

Contributors guide: ./CONTRIBUTING.md
Code of conduct: ./CODE_OF_CONDUCT.md
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.

Fixes #
restore step failed on windows pipelines. bug fixed where tar was being created with relative filename because filepath was not being checked correctly for being absolute or relative

## Proposed Changes
<!-- Please briefly list the changes you made here. -->

- changed code to make it use default go function instead of checking filepath prefix manually

