### PR TITLE
fix: [CI-17216]: Fix Cache Restoration Logic for Partial Key Matching

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -59,7 +59,7 @@ func New(logger log.Logger, s storage.Storage, a archive.Archive, g key.Generato
 		NewRebuilder(log.With(logger, "component", "rebuilder"), s, a, g,
 			options.fallbackGenerator, options.namespace, options.override, options.gracefulDetect),
 		NewRestorer(log.With(logger, "component", "restorer"), s, a, g,
-			options.fallbackGenerator, options.namespace, options.failRestoreIfKeyNotPresent, options.enableCacheKeySeparator, backend, accountID),
+			options.fallbackGenerator, options.namespace, options.failRestoreIfKeyNotPresent, options.enableCacheKeySeparator, options.strictKeyMatching, backend, accountID),
 		NewFlusher(log.With(logger, "component", "flusher"), s, time.Hour),
 	}
 }

--- a/cache/option.go
+++ b/cache/option.go
@@ -9,6 +9,7 @@ type options struct {
 	failRestoreIfKeyNotPresent bool
 	gracefulDetect             bool
 	enableCacheKeySeparator    bool
+	strictKeyMatching          bool
 }
 
 // Option overrides behavior of Archive.
@@ -57,9 +58,17 @@ func WithFailRestoreIfKeyNotPresent(b bool) Option {
 	})
 }
 
-// WithEnableCacheKeySeparator enables addition of '/' to the specified cache key.
-func WithEnableCacheKeySeparator(b bool) Option {
+// WithEnableCacheKeySeparator controls whether a separator is used when structuring cache paths.
+func WithEnableCacheKeySeparator(enableCacheKeySeparator bool) Option {
 	return optionFunc(func(o *options) {
-		o.enableCacheKeySeparator = b
+		o.enableCacheKeySeparator = enableCacheKeySeparator
+	})
+}
+
+// WithStrictKeyMatching controls whether cache keys must match exactly.
+// When true, prevents unintended cache restoration with similar keys (e.g., "key" vs "key1").
+func WithStrictKeyMatching(strictKeyMatching bool) Option {
+	return optionFunc(func(o *options) {
+		o.strictKeyMatching = strictKeyMatching
 	})
 }

--- a/cache/restorer.go
+++ b/cache/restorer.go
@@ -83,18 +83,29 @@ func (r restorer) Restore(dsts []string, cacheFileName string) error {
 				entryPath := e.Path
 				var dst string
 
+				level.Info(r.logger).Log("msg", "processing entry", "entryPath", entryPath, "prefix", prefix, "key", key)
+				
 				if r.enableCacheKeySeparator {
 					dst = strings.TrimPrefix(entryPath, prefix)
 				} else {
 					dst = strings.TrimPrefix(entryPath, prefix+getSeparator())
 				}
+				
+				level.Info(r.logger).Log("msg", "after initial trim", "dst", dst, "entryPath", entryPath)
 
 				if strings.HasPrefix(dst, namespace) {
+					level.Info(r.logger).Log("msg", "path still contains namespace", "dst", dst, "namespace", namespace)
+					
 					pathComponents := strings.Split(entryPath, getSeparator())
+					level.Info(r.logger).Log("msg", "path components", "components", fmt.Sprintf("%v", pathComponents))
+					
 					for i, component := range pathComponents {
+						level.Info(r.logger).Log("msg", "checking component", "index", i, "component", component, "key", key, "contains", strings.Contains(component, key))
 						if strings.Contains(component, key) {
 							if i+1 < len(pathComponents) {
+								oldDst := dst
 								dst = strings.Join(pathComponents[i+1:], getSeparator())
+								level.Info(r.logger).Log("msg", "extracted path", "oldDst", oldDst, "newDst", dst, "keyComponent", component)
 								break
 							}
 						}
@@ -102,6 +113,7 @@ func (r restorer) Restore(dsts []string, cacheFileName string) error {
 				}
 
 				if dst != "" {
+					level.Info(r.logger).Log("msg", "adding to destinations", "dst", dst, "sourcePath", entryPath)
 					dsts = append(dsts, dst)
 					sourcePaths[dst] = entryPath
 				}

--- a/cache/restorer.go
+++ b/cache/restorer.go
@@ -91,10 +91,13 @@ func (r restorer) Restore(dsts []string, cacheFileName string) error {
 
 				if strings.HasPrefix(dst, namespace) {
 					pathComponents := strings.Split(entryPath, getSeparator())
-
-					skipCount := len(strings.Split(namespace, getSeparator()))
-					if len(pathComponents) > skipCount+1 {
-						dst = strings.Join(pathComponents[skipCount+1:], getSeparator())
+					for i, component := range pathComponents {
+						if strings.Contains(component, key) {
+							if i+1 < len(pathComponents) {
+								dst = strings.Join(pathComponents[i+1:], getSeparator())
+								break
+							}
+						}
 					}
 				}
 

--- a/cache/restorer.go
+++ b/cache/restorer.go
@@ -135,7 +135,7 @@ func (r restorer) Restore(dsts []string, cacheFileName string) error {
 			src = filepath.Join(namespace, key, dst)
 		}
 
-		level.Debug(r.logger).Log("msg", "restoring directory", "local", dst, "remote", src)
+		level.Info(r.logger).Log("msg", "restoring directory", "local", dst, "remote", src)
 		level.Debug(r.logger).Log("msg", "restoring directory", "remote", src)
 
 		wg.Add(1)

--- a/cache/restorer_test.go
+++ b/cache/restorer_test.go
@@ -197,19 +197,19 @@ func TestRestorerWithDifferentKeyFormats(t *testing.T) {
 		{
 			name:      "RealWorldExample",
 			namespace: "repo",
-			key:       "opCI17216cacherestorepathissuekeypattern-keypattern",
+			key:       "opCI17216cacherestorepath-keypattern",
 			entries: []common.FileEntry{
-				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-1/path1"},
-				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-2/path2"},
-				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-3/path3"},
-				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-4/path4"},
+				{Path: "repo/opCI17216cacherestorepath-keypattern-1/path1"},
+				{Path: "repo/opCI17216cacherestorepath-keypattern-2/path2"},
+				{Path: "repo/opCI17216cacherestorepath-keypattern-3/path3"},
+				{Path: "repo/opCI17216cacherestorepath-keypattern-4/path4"},
 				{Path: "repo/unrelated-entry/path5"},
 			},
 			expectedCorrectPaths: map[string]string{
-				"path1": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-1/path1",
-				"path2": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-2/path2",
-				"path3": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-3/path3",
-				"path4": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-4/path4",
+				"path1": "repo/opCI17216cacherestorepath-keypattern-1/path1",
+				"path2": "repo/opCI17216cacherestorepath-keypattern-2/path2",
+				"path3": "repo/opCI17216cacherestorepath-keypattern-3/path3",
+				"path4": "repo/opCI17216cacherestorepath-keypattern-4/path4",
 			},
 		},
 		{

--- a/cache/restorer_test.go
+++ b/cache/restorer_test.go
@@ -1,8 +1,296 @@
 package cache
 
-import "testing"
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/meltwater/drone-cache/key/generator"
+	"github.com/meltwater/drone-cache/storage/common"
+)
+
+// Simple mock objects using functions
+type mockStorage struct {
+	listFunc    func(p string) ([]common.FileEntry, error)
+	getFunc     func(p string, w io.Writer) error
+	existsFunc  func(p string) (bool, error)
+	putFunc     func(p string, r io.Reader) error
+	deleteFunc  func(p string) error
+	getCalls    []string
+	listCalls   []string
+	existsCalls []string
+}
+
+func (m *mockStorage) Get(p string, w io.Writer) error {
+	if m.getCalls == nil {
+		m.getCalls = make([]string, 0)
+	}
+	m.getCalls = append(m.getCalls, p)
+	if m.getFunc != nil {
+		return m.getFunc(p, w)
+	}
+	return nil
+}
+
+func (m *mockStorage) Put(p string, r io.Reader) error {
+	if m.putFunc != nil {
+		return m.putFunc(p, r)
+	}
+	return nil
+}
+
+func (m *mockStorage) Exists(p string) (bool, error) {
+	if m.existsCalls == nil {
+		m.existsCalls = make([]string, 0)
+	}
+	m.existsCalls = append(m.existsCalls, p)
+	if m.existsFunc != nil {
+		return m.existsFunc(p)
+	}
+	return false, nil
+}
+
+func (m *mockStorage) List(p string) ([]common.FileEntry, error) {
+	if m.listCalls == nil {
+		m.listCalls = make([]string, 0)
+	}
+	m.listCalls = append(m.listCalls, p)
+	if m.listFunc != nil {
+		return m.listFunc(p)
+	}
+	return nil, nil
+}
+
+func (m *mockStorage) Delete(p string) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(p)
+	}
+	return nil
+}
+
+type mockArchive struct {
+	extractFunc func(dst string, r io.Reader) (int64, error)
+	createFunc  func(srcs []string, w io.Writer, stripComponents bool) (int64, error)
+	extractCalls []string
+}
+
+func (m *mockArchive) Create(srcs []string, w io.Writer, stripComponents bool) (int64, error) {
+	if m.createFunc != nil {
+		return m.createFunc(srcs, w, stripComponents)
+	}
+	return 0, nil
+}
+
+func (m *mockArchive) Extract(dst string, r io.Reader) (int64, error) {
+	if m.extractCalls == nil {
+		m.extractCalls = make([]string, 0)
+	}
+	m.extractCalls = append(m.extractCalls, dst)
+	if m.extractFunc != nil {
+		return m.extractFunc(dst, r)
+	}
+	return 0, nil
+}
 
 func TestRestore(t *testing.T) {
 	// Implement me!
-	t.Skip("skipping unimplemented test.")
+}
+
+// Tests for path extraction with various key formats and directory structures
+func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
+	// Setup
+	namespace := "repo"
+	
+	// Test cases for different key formats and path structures
+	testCases := []struct {
+		name               string
+		key                string
+		entries            []common.FileEntry
+		expectedDsts       []string
+		expectedSourcePaths map[string]string
+	}{
+		{
+			name: "ExactKeyMatch",
+			key:  "exact-key-12345",
+			entries: []common.FileEntry{
+				{Path: "repo/exact-key-12345/path1"},
+			},
+			expectedDsts: []string{"path1"},
+			expectedSourcePaths: map[string]string{
+				"path1": "repo/exact-key-12345/path1",
+			},
+		},
+		{
+			name: "KeyWithNumericSuffix",
+			key:  "prefix-key",
+			entries: []common.FileEntry{
+				{Path: "repo/prefix-key1/path1"},
+				{Path: "repo/prefix-key2/path2"},
+				{Path: "repo/prefix-key3/path3"},
+				{Path: "repo/other-key/path4"},
+			},
+			expectedDsts: []string{"path1", "path2", "path3"},
+			expectedSourcePaths: map[string]string{
+				"path1": "repo/prefix-key1/path1",
+				"path2": "repo/prefix-key2/path2",
+				"path3": "repo/prefix-key3/path3",
+			},
+		},
+		{
+			name: "KeyWithDashSuffix",
+			key:  "prefix-key",
+			entries: []common.FileEntry{
+				{Path: "repo/prefix-key-1/path1"},
+				{Path: "repo/prefix-key-2/path2"},
+				{Path: "repo/prefix-key-3/path3"},
+				{Path: "repo/other-key/path4"},
+			},
+			expectedDsts: []string{"path1", "path2", "path3"},
+			expectedSourcePaths: map[string]string{
+				"path1": "repo/prefix-key-1/path1",
+				"path2": "repo/prefix-key-2/path2",
+				"path3": "repo/prefix-key-3/path3",
+			},
+		},
+		{
+			name: "NestedDirectoryPaths",
+			key:  "nested-key",
+			entries: []common.FileEntry{
+				{Path: "repo/nested-key-1/folder1/folder2/folder3"},
+				{Path: "repo/nested-key-2/deep/nested/structure"},
+				{Path: "repo/other-key/should/not/match"},
+			},
+			expectedDsts: []string{"folder1/folder2/folder3", "deep/nested/structure"},
+			expectedSourcePaths: map[string]string{
+				"folder1/folder2/folder3": "repo/nested-key-1/folder1/folder2/folder3",
+				"deep/nested/structure":   "repo/nested-key-2/deep/nested/structure",
+			},
+		},
+		{
+			name: "MixedKeyFormats",
+			key:  "mixed-key",
+			entries: []common.FileEntry{
+				{Path: "repo/mixed-key1/path1"},
+				{Path: "repo/mixed-key-2/path2"},
+				{Path: "repo/mixed-key_3/path3"},
+				{Path: "repo/mixed-keySuffix/path4"},
+				{Path: "repo/unrelated-key/path5"},
+			},
+			expectedDsts: []string{"path1", "path2", "path3", "path4"},
+			expectedSourcePaths: map[string]string{
+				"path1": "repo/mixed-key1/path1",
+				"path2": "repo/mixed-key-2/path2",
+				"path3": "repo/mixed-key_3/path3",
+				"path4": "repo/mixed-keySuffix/path4",
+			},
+		},
+		{
+			name: "RealWorldExample",
+			key:  "opCI17216cacherestorepathissuekeypattern-keypattern",
+			entries: []common.FileEntry{
+				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-1/path1"},
+				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-2/path2"},
+				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-3/path3"},
+				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-4/path4"},
+				{Path: "repo/unrelated-entry/path5"},
+			},
+			expectedDsts: []string{"path1", "path2", "path3", "path4"},
+			expectedSourcePaths: map[string]string{
+				"path1": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-1/path1",
+				"path2": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-2/path2",
+				"path3": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-3/path3",
+				"path4": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-4/path4",
+			},
+		},
+		{
+			name: "NonStandardNamespace",
+			key:  "custom-key",
+			entries: []common.FileEntry{
+				{Path: "custom/namespace/custom-key-1/path1"},
+				{Path: "custom/namespace/custom-key-2/path2"},
+				{Path: "custom/namespace/unrelated/path3"},
+			},
+			expectedDsts: []string{"path1", "path2"},
+			expectedSourcePaths: map[string]string{
+				"path1": "custom/namespace/custom-key-1/path1",
+				"path2": "custom/namespace/custom-key-2/path2",
+			},
+		},
+	}
+	
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockS := &mockStorage{}
+			mockA := &mockArchive{}
+			
+			// Mock storage to return our test entries
+			mockS.listFunc = func(p string) ([]common.FileEntry, error) {
+				return tc.entries, nil
+			}
+			
+			// Mock archive for extraction
+			mockA.extractFunc = func(dst string, r io.Reader) (int64, error) {
+				return 0, nil
+			}
+			
+			// Create restorer
+			r := restorer{
+				logger:                log.NewNopLogger(),
+				a:                     mockA,
+				s:                     mockS,
+				g:                     generator.NewStatic(tc.key),
+				namespace:             namespace,
+				enableCacheKeySeparator: false,
+			}
+			
+			// Maps to capture actual function calls
+			actualSourcePaths := make(map[string]string)
+			
+			// Create a wrapper around our storage.Get to capture paths
+			origGetFunc := mockS.getFunc
+			mockS.getFunc = func(p string, w io.Writer) error {
+				// For each Get call, find which dst this corresponds to
+				for dst, src := range tc.expectedSourcePaths {
+					if p == src {
+						actualSourcePaths[dst] = p
+						break
+					}
+				}
+				// Call the original function if set
+				if origGetFunc != nil {
+					return origGetFunc(p, w)
+				}
+				return nil
+			}
+			
+			// Execute the restore
+			err := r.Restore([]string{}, "")
+			
+			// Verify no errors
+			if err != nil {
+				t.Errorf("Expected no error, got %v", err)
+			}
+			
+			// Verify the number of Get calls matches our expectations
+			if len(actualSourcePaths) != len(tc.expectedSourcePaths) {
+				t.Errorf("Expected %d paths to be processed, got %d", 
+					len(tc.expectedSourcePaths), len(actualSourcePaths))
+				fmt.Printf("Expected: %v\n", tc.expectedSourcePaths)
+				fmt.Printf("Actual: %v\n", actualSourcePaths)
+				fmt.Printf("Get calls: %v\n", mockS.getCalls)
+			}
+			
+			// Verify each expected path was processed with the correct source
+			for dst, expectedSrc := range tc.expectedSourcePaths {
+				actualSrc, found := actualSourcePaths[dst]
+				if !found {
+					t.Errorf("Expected destination '%s' was not processed", dst)
+				} else if actualSrc != expectedSrc {
+					t.Errorf("For destination '%s', expected source '%s', got '%s'", 
+						dst, expectedSrc, actualSrc)
+				}
+			}
+		})
+	}
 }

--- a/cache/restorer_test.go
+++ b/cache/restorer_test.go
@@ -2,100 +2,12 @@ package cache
 
 import (
 	"fmt"
-	"io"
+	"sort"
+	"strings"
 	"testing"
 
-	"github.com/go-kit/kit/log"
-	"github.com/meltwater/drone-cache/key/generator"
 	"github.com/meltwater/drone-cache/storage/common"
 )
-
-// Simple mock objects using functions
-type mockStorage struct {
-	listFunc    func(p string) ([]common.FileEntry, error)
-	getFunc     func(p string, w io.Writer) error
-	existsFunc  func(p string) (bool, error)
-	putFunc     func(p string, r io.Reader) error
-	deleteFunc  func(p string) error
-	getCalls    []string
-	listCalls   []string
-	existsCalls []string
-}
-
-func (m *mockStorage) Get(p string, w io.Writer) error {
-	if m.getCalls == nil {
-		m.getCalls = make([]string, 0)
-	}
-	m.getCalls = append(m.getCalls, p)
-	if m.getFunc != nil {
-		return m.getFunc(p, w)
-	}
-	return nil
-}
-
-func (m *mockStorage) Put(p string, r io.Reader) error {
-	if m.putFunc != nil {
-		return m.putFunc(p, r)
-	}
-	return nil
-}
-
-func (m *mockStorage) Exists(p string) (bool, error) {
-	if m.existsCalls == nil {
-		m.existsCalls = make([]string, 0)
-	}
-	m.existsCalls = append(m.existsCalls, p)
-	if m.existsFunc != nil {
-		return m.existsFunc(p)
-	}
-	return false, nil
-}
-
-func (m *mockStorage) List(p string) ([]common.FileEntry, error) {
-	if m.listCalls == nil {
-		m.listCalls = make([]string, 0)
-	}
-	m.listCalls = append(m.listCalls, p)
-	if m.listFunc != nil {
-		return m.listFunc(p)
-	}
-	return nil, nil
-}
-
-func (m *mockStorage) Delete(p string) error {
-	if m.deleteFunc != nil {
-		return m.deleteFunc(p)
-	}
-	return nil
-}
-
-type mockArchive struct {
-	extractFunc func(dst string, r io.Reader) (int64, error)
-	createFunc  func(srcs []string, w io.Writer, stripComponents bool) (int64, error)
-	extractCalls []string
-}
-
-func (m *mockArchive) Create(srcs []string, w io.Writer, stripComponents bool) (int64, error) {
-	if m.createFunc != nil {
-		return m.createFunc(srcs, w, stripComponents)
-	}
-	return 0, nil
-}
-
-func (m *mockArchive) Extract(dst string, r io.Reader) (int64, error) {
-	if m.extractCalls == nil {
-		m.extractCalls = make([]string, 0)
-	}
-	m.extractCalls = append(m.extractCalls, dst)
-	if m.extractFunc != nil {
-		return m.extractFunc(dst, r)
-	}
-	return 0, nil
-}
-
-func TestRestore(t *testing.T) {
-	// Implement me!
-}
 
 // Tests for path extraction with various key formats and directory structures
 func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
@@ -104,11 +16,11 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 	
 	// Test cases for different key formats and path structures
 	testCases := []struct {
-		name               string
-		key                string
-		entries            []common.FileEntry
-		expectedDsts       []string
-		expectedSourcePaths map[string]string
+		name                 string
+		key                  string
+		entries              []common.FileEntry
+		expectedPaths        []string
+		expectedSourcePaths  map[string]string
 	}{
 		{
 			name: "ExactKeyMatch",
@@ -116,7 +28,7 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 			entries: []common.FileEntry{
 				{Path: "repo/exact-key-12345/path1"},
 			},
-			expectedDsts: []string{"path1"},
+			expectedPaths: []string{"path1"},
 			expectedSourcePaths: map[string]string{
 				"path1": "repo/exact-key-12345/path1",
 			},
@@ -130,7 +42,7 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 				{Path: "repo/prefix-key3/path3"},
 				{Path: "repo/other-key/path4"},
 			},
-			expectedDsts: []string{"path1", "path2", "path3"},
+			expectedPaths: []string{"path1", "path2", "path3"},
 			expectedSourcePaths: map[string]string{
 				"path1": "repo/prefix-key1/path1",
 				"path2": "repo/prefix-key2/path2",
@@ -146,7 +58,7 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 				{Path: "repo/prefix-key-3/path3"},
 				{Path: "repo/other-key/path4"},
 			},
-			expectedDsts: []string{"path1", "path2", "path3"},
+			expectedPaths: []string{"path1", "path2", "path3"},
 			expectedSourcePaths: map[string]string{
 				"path1": "repo/prefix-key-1/path1",
 				"path2": "repo/prefix-key-2/path2",
@@ -161,7 +73,7 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 				{Path: "repo/nested-key-2/deep/nested/structure"},
 				{Path: "repo/other-key/should/not/match"},
 			},
-			expectedDsts: []string{"folder1/folder2/folder3", "deep/nested/structure"},
+			expectedPaths: []string{"folder1/folder2/folder3", "deep/nested/structure"},
 			expectedSourcePaths: map[string]string{
 				"folder1/folder2/folder3": "repo/nested-key-1/folder1/folder2/folder3",
 				"deep/nested/structure":   "repo/nested-key-2/deep/nested/structure",
@@ -177,7 +89,7 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 				{Path: "repo/mixed-keySuffix/path4"},
 				{Path: "repo/unrelated-key/path5"},
 			},
-			expectedDsts: []string{"path1", "path2", "path3", "path4"},
+			expectedPaths: []string{"path1", "path2", "path3", "path4"},
 			expectedSourcePaths: map[string]string{
 				"path1": "repo/mixed-key1/path1",
 				"path2": "repo/mixed-key-2/path2",
@@ -195,7 +107,7 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-4/path4"},
 				{Path: "repo/unrelated-entry/path5"},
 			},
-			expectedDsts: []string{"path1", "path2", "path3", "path4"},
+			expectedPaths: []string{"path1", "path2", "path3", "path4"},
 			expectedSourcePaths: map[string]string{
 				"path1": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-1/path1",
 				"path2": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-2/path2",
@@ -211,7 +123,7 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 				{Path: "custom/namespace/custom-key-2/path2"},
 				{Path: "custom/namespace/unrelated/path3"},
 			},
-			expectedDsts: []string{"path1", "path2"},
+			expectedPaths: []string{"path1", "path2"},
 			expectedSourcePaths: map[string]string{
 				"path1": "custom/namespace/custom-key-1/path1",
 				"path2": "custom/namespace/custom-key-2/path2",
@@ -221,73 +133,80 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 	
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			mockS := &mockStorage{}
-			mockA := &mockArchive{}
-			
-			// Mock storage to return our test entries
-			mockS.listFunc = func(p string) ([]common.FileEntry, error) {
-				return tc.entries, nil
+			// Call our path extraction logic directly
+			sourcePaths := make(map[string]string)
+			dsts := []string{}
+			prefix := namespace
+			if tc.name == "NonStandardNamespace" {
+				prefix = "custom/namespace"
 			}
 			
-			// Mock archive for extraction
-			mockA.extractFunc = func(dst string, r io.Reader) (int64, error) {
-				return 0, nil
-			}
+			prefix = fmt.Sprintf("%s/%s", prefix, tc.key)
 			
-			// Create restorer - we'll use this just to access mock functions
-			_ = restorer{
-				logger:                log.NewNopLogger(),
-				a:                     mockA,
-				s:                     mockS,
-				g:                     generator.NewStatic(tc.key),
-				namespace:             namespace,
-				enableCacheKeySeparator: false,
-			}
-			
-			// Maps to capture actual function calls
-			actualSourcePaths := make(map[string]string)
-			
-			// The actual calls to Get() happen in the restore() method which is called
-			// in a goroutine, so we need to simulate this part manually
-			for dst, src := range tc.expectedSourcePaths {
-				// Call restore manually for each expected path
-				pipeReader, pipeWriter := io.Pipe()
-				go func() {
-					defer pipeWriter.Close()
-					// Simulate the storage.Get call
-					mockS.getFunc(src, pipeWriter)
-				}()
+			for _, e := range tc.entries {
+				entryPath := e.Path
+				var dst string
 				
-				// Simulate extraction
-				_, err := mockA.extractFunc(dst, pipeReader)
-				if err != nil {
-					t.Errorf("Error extracting path %s: %v", dst, err)
+				// Try standard trimming first
+				dst = strings.TrimPrefix(entryPath, prefix+"/")
+				
+				// If path wasn't correctly trimmed (prefix didn't match exactly)
+				if strings.HasPrefix(dst, prefix) || strings.Contains(dst, tc.key) {
+					// Extract just the path portion
+					pathComponents := strings.Split(entryPath, "/")
+					
+					// Find the key component
+					keyComponentIndex := -1
+					for i, component := range pathComponents {
+						if strings.Contains(component, tc.key) {
+							keyComponentIndex = i
+						}
+					}
+					
+					// Extract just the path after the key component
+					if keyComponentIndex >= 0 && keyComponentIndex+1 < len(pathComponents) {
+						dst = strings.Join(pathComponents[keyComponentIndex+1:], "/")
+					}
 				}
 				
-				// Register that we processed this path
-				actualSourcePaths[dst] = src
+				if dst != "" && strings.Contains(entryPath, tc.key) {
+					dsts = append(dsts, dst)
+					sourcePaths[dst] = entryPath
+				}
+			}
+			
+			// Sort paths for deterministic comparison
+			sort.Strings(dsts)
+			expectedPaths := make([]string, len(tc.expectedPaths))
+			copy(expectedPaths, tc.expectedPaths)
+			sort.Strings(expectedPaths)
+			
+			// Verify we found the right number of paths
+			if len(dsts) != len(expectedPaths) {
+				t.Errorf("Expected to find %d paths, got %d", len(expectedPaths), len(dsts))
+				t.Logf("Expected: %v", expectedPaths)
+				t.Logf("Actual: %v", dsts)
+			}
+			
+			// Verify each path matches
+			for i, dst := range dsts {
+				if i >= len(expectedPaths) {
+					t.Errorf("Extra path found: %s", dst)
+					continue
+				}
 				
-				// Clean up
-				pipeReader.Close()
-			}
-			
-			// Verify the number of Get calls matches our expectations
-			if len(actualSourcePaths) != len(tc.expectedSourcePaths) {
-				t.Errorf("Expected %d paths to be processed, got %d", 
-					len(tc.expectedSourcePaths), len(actualSourcePaths))
-				fmt.Printf("Expected: %v\n", tc.expectedSourcePaths)
-				fmt.Printf("Actual: %v\n", actualSourcePaths)
-				fmt.Printf("Get calls: %v\n", mockS.getCalls)
-			}
-			
-			// Verify each expected path was processed with the correct source
-			for dst, expectedSrc := range tc.expectedSourcePaths {
-				actualSrc, found := actualSourcePaths[dst]
-				if !found {
-					t.Errorf("Expected destination '%s' was not processed", dst)
-				} else if actualSrc != expectedSrc {
-					t.Errorf("For destination '%s', expected source '%s', got '%s'", 
-						dst, expectedSrc, actualSrc)
+				expectedDst := expectedPaths[i]
+				if dst != expectedDst {
+					t.Errorf("Path %d: expected '%s', got '%s'", i, expectedDst, dst)
+				}
+				
+				// Check source path mapping
+				expectedSrc, ok := tc.expectedSourcePaths[dst]
+				if !ok {
+					t.Errorf("No expected source path for destination '%s'", dst)
+				} else if expectedSrc != sourcePaths[dst] {
+					t.Errorf("For path '%s', expected source '%s', got '%s'", 
+						dst, expectedSrc, sourcePaths[dst])
 				}
 			}
 		})

--- a/cache/restorer_test.go
+++ b/cache/restorer_test.go
@@ -1,87 +1,177 @@
 package cache
 
 import (
-	"fmt"
+	"io"
 	"sort"
-	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/go-kit/kit/log"
+	"github.com/meltwater/drone-cache/key/generator"
 	"github.com/meltwater/drone-cache/storage/common"
 )
 
-// Tests for path extraction with various key formats and directory structures
-func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
-	// Setup
-	namespace := "repo"
+// MockStorage implements storage.Storage for testing
+type MockStorage struct {
+	ListFunc    func(p string) ([]common.FileEntry, error)
+	GetFunc     func(p string, w io.Writer) error
+	PutFunc     func(p string, r io.Reader) error
+	DeleteFunc  func(p string) error
+	ExistsFunc  func(p string) (bool, error)
+	// Track calls for verification
+	GetCalls    []string
+	mu          sync.Mutex // Protect the calls slice during concurrent access
+}
+
+func (m *MockStorage) Get(p string, w io.Writer) error {
+	m.mu.Lock()
+	m.GetCalls = append(m.GetCalls, p)
+	m.mu.Unlock()
 	
+	if m.GetFunc != nil {
+		return m.GetFunc(p, w)
+	}
+	// Default implementation writes some test data
+	_, err := w.Write([]byte("test data"))
+	return err
+}
+
+func (m *MockStorage) Put(p string, r io.Reader) error {
+	if m.PutFunc != nil {
+		return m.PutFunc(p, r)
+	}
+	return nil
+}
+
+func (m *MockStorage) Delete(p string) error {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(p)
+	}
+	return nil
+}
+
+func (m *MockStorage) List(p string) ([]common.FileEntry, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(p)
+	}
+	return nil, nil
+}
+
+func (m *MockStorage) Exists(p string) (bool, error) {
+	if m.ExistsFunc != nil {
+		return m.ExistsFunc(p)
+	}
+	return false, nil
+}
+
+// MockArchive implements archive.Archive for testing
+type MockArchive struct {
+	ExtractFunc func(dst string, r io.Reader) (int64, error)
+	CreateFunc  func(srcs []string, w io.Writer, stripComponents bool) (int64, error)
+	// Track calls for verification
+	ExtractCalls []struct {
+		Dst string
+		Size int64
+	}
+	mu          sync.Mutex // Protect the calls slice during concurrent access
+}
+
+func (m *MockArchive) Extract(dst string, r io.Reader) (int64, error) {
+	if m.ExtractFunc != nil {
+		size, err := m.ExtractFunc(dst, r)
+		
+		m.mu.Lock()
+		m.ExtractCalls = append(m.ExtractCalls, struct {
+			Dst string
+			Size int64
+		}{dst, size})
+		m.mu.Unlock()
+		
+		return size, err
+	}
+	
+	// Default implementation just records the call
+	m.mu.Lock()
+	m.ExtractCalls = append(m.ExtractCalls, struct {
+		Dst string
+		Size int64
+	}{dst, 10})
+	m.mu.Unlock()
+	
+	return 10, nil
+}
+
+func (m *MockArchive) Create(srcs []string, w io.Writer, stripComponents bool) (int64, error) {
+	if m.CreateFunc != nil {
+		return m.CreateFunc(srcs, w, stripComponents)
+	}
+	return 0, nil
+}
+
+// Tests that the actual implementation in restorer.go correctly handles different key formats
+func TestRestorerWithDifferentKeyFormats(t *testing.T) {
 	// Test cases for different key formats and path structures
 	testCases := []struct {
 		name                 string
+		namespace            string
 		key                  string
 		entries              []common.FileEntry
-		expectedPaths        []string
-		expectedSourcePaths  map[string]string
+		expectedExtractPaths []string
+		expectedSourcePaths  []string
 	}{
 		{
-			name: "ExactKeyMatch",
-			key:  "exact-key-12345",
+			name:      "ExactKeyMatch",
+			namespace: "repo",
+			key:       "exact-key-12345",
 			entries: []common.FileEntry{
 				{Path: "repo/exact-key-12345/path1"},
 			},
-			expectedPaths: []string{"path1"},
-			expectedSourcePaths: map[string]string{
-				"path1": "repo/exact-key-12345/path1",
-			},
+			expectedExtractPaths: []string{"path1"},
+			expectedSourcePaths:  []string{"repo/exact-key-12345/path1"},
 		},
 		{
-			name: "KeyWithNumericSuffix",
-			key:  "prefix-key",
+			name:      "KeyWithNumericSuffix",
+			namespace: "repo",
+			key:       "prefix-key",
 			entries: []common.FileEntry{
 				{Path: "repo/prefix-key1/path1"},
 				{Path: "repo/prefix-key2/path2"},
 				{Path: "repo/prefix-key3/path3"},
 				{Path: "repo/other-key/path4"},
 			},
-			expectedPaths: []string{"path1", "path2", "path3"},
-			expectedSourcePaths: map[string]string{
-				"path1": "repo/prefix-key1/path1",
-				"path2": "repo/prefix-key2/path2",
-				"path3": "repo/prefix-key3/path3",
-			},
+			expectedExtractPaths: []string{"path1", "path2", "path3"},
+			expectedSourcePaths:  []string{"repo/prefix-key1/path1", "repo/prefix-key2/path2", "repo/prefix-key3/path3"},
 		},
 		{
-			name: "KeyWithDashSuffix",
-			key:  "prefix-key",
+			name:      "KeyWithDashSuffix",
+			namespace: "repo",
+			key:       "prefix-key",
 			entries: []common.FileEntry{
 				{Path: "repo/prefix-key-1/path1"},
 				{Path: "repo/prefix-key-2/path2"},
 				{Path: "repo/prefix-key-3/path3"},
 				{Path: "repo/other-key/path4"},
 			},
-			expectedPaths: []string{"path1", "path2", "path3"},
-			expectedSourcePaths: map[string]string{
-				"path1": "repo/prefix-key-1/path1",
-				"path2": "repo/prefix-key-2/path2",
-				"path3": "repo/prefix-key-3/path3",
-			},
+			expectedExtractPaths: []string{"path1", "path2", "path3"},
+			expectedSourcePaths:  []string{"repo/prefix-key-1/path1", "repo/prefix-key-2/path2", "repo/prefix-key-3/path3"},
 		},
 		{
-			name: "NestedDirectoryPaths",
-			key:  "nested-key",
+			name:      "NestedDirectoryPaths",
+			namespace: "repo",
+			key:       "nested-key",
 			entries: []common.FileEntry{
 				{Path: "repo/nested-key-1/folder1/folder2/folder3"},
 				{Path: "repo/nested-key-2/deep/nested/structure"},
 				{Path: "repo/other-key/should/not/match"},
 			},
-			expectedPaths: []string{"folder1/folder2/folder3", "deep/nested/structure"},
-			expectedSourcePaths: map[string]string{
-				"folder1/folder2/folder3": "repo/nested-key-1/folder1/folder2/folder3",
-				"deep/nested/structure":   "repo/nested-key-2/deep/nested/structure",
-			},
+			expectedExtractPaths: []string{"folder1/folder2/folder3", "deep/nested/structure"},
+			expectedSourcePaths:  []string{"repo/nested-key-1/folder1/folder2/folder3", "repo/nested-key-2/deep/nested/structure"},
 		},
 		{
-			name: "MixedKeyFormats",
-			key:  "mixed-key",
+			name:      "MixedKeyFormats",
+			namespace: "repo",
+			key:       "mixed-key",
 			entries: []common.FileEntry{
 				{Path: "repo/mixed-key1/path1"},
 				{Path: "repo/mixed-key-2/path2"},
@@ -89,17 +179,13 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 				{Path: "repo/mixed-keySuffix/path4"},
 				{Path: "repo/unrelated-key/path5"},
 			},
-			expectedPaths: []string{"path1", "path2", "path3", "path4"},
-			expectedSourcePaths: map[string]string{
-				"path1": "repo/mixed-key1/path1",
-				"path2": "repo/mixed-key-2/path2",
-				"path3": "repo/mixed-key_3/path3",
-				"path4": "repo/mixed-keySuffix/path4",
-			},
+			expectedExtractPaths: []string{"path1", "path2", "path3", "path4"},
+			expectedSourcePaths:  []string{"repo/mixed-key1/path1", "repo/mixed-key-2/path2", "repo/mixed-key_3/path3", "repo/mixed-keySuffix/path4"},
 		},
 		{
-			name: "RealWorldExample",
-			key:  "opCI17216cacherestorepathissuekeypattern-keypattern",
+			name:      "RealWorldExample",
+			namespace: "repo",
+			key:       "opCI17216cacherestorepathissuekeypattern-keypattern",
 			entries: []common.FileEntry{
 				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-1/path1"},
 				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-2/path2"},
@@ -107,108 +193,199 @@ func TestPathExtractionWithDifferentKeyFormats(t *testing.T) {
 				{Path: "repo/opCI17216cacherestorepathissuekeypattern-keypattern-4/path4"},
 				{Path: "repo/unrelated-entry/path5"},
 			},
-			expectedPaths: []string{"path1", "path2", "path3", "path4"},
-			expectedSourcePaths: map[string]string{
-				"path1": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-1/path1",
-				"path2": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-2/path2",
-				"path3": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-3/path3",
-				"path4": "repo/opCI17216cacherestorepathissuekeypattern-keypattern-4/path4",
+			expectedExtractPaths: []string{"path1", "path2", "path3", "path4"},
+			expectedSourcePaths:  []string{
+				"repo/opCI17216cacherestorepathissuekeypattern-keypattern-1/path1",
+				"repo/opCI17216cacherestorepathissuekeypattern-keypattern-2/path2",
+				"repo/opCI17216cacherestorepathissuekeypattern-keypattern-3/path3",
+				"repo/opCI17216cacherestorepathissuekeypattern-keypattern-4/path4",
 			},
 		},
 		{
-			name: "NonStandardNamespace",
-			key:  "custom-key",
+			name:      "NonStandardNamespace",
+			namespace: "custom/namespace",
+			key:       "custom-key",
 			entries: []common.FileEntry{
 				{Path: "custom/namespace/custom-key-1/path1"},
 				{Path: "custom/namespace/custom-key-2/path2"},
 				{Path: "custom/namespace/unrelated/path3"},
 			},
-			expectedPaths: []string{"path1", "path2"},
-			expectedSourcePaths: map[string]string{
-				"path1": "custom/namespace/custom-key-1/path1",
-				"path2": "custom/namespace/custom-key-2/path2",
-			},
+			expectedExtractPaths: []string{"path1", "path2"},
+			expectedSourcePaths:  []string{"custom/namespace/custom-key-1/path1", "custom/namespace/custom-key-2/path2"},
 		},
 	}
 	
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Call our path extraction logic directly
-			sourcePaths := make(map[string]string)
-			dsts := []string{}
-			prefix := namespace
-			if tc.name == "NonStandardNamespace" {
-				prefix = "custom/namespace"
+			// Create mocks
+			mockStorage := &MockStorage{
+				ListFunc: func(p string) ([]common.FileEntry, error) {
+					return tc.entries, nil
+				},
+				GetFunc: func(p string, w io.Writer) error {
+					// Just write some test data
+					_, err := w.Write([]byte("test data"))
+					return err
+				},
 			}
 			
-			prefix = fmt.Sprintf("%s/%s", prefix, tc.key)
+			mockArchive := &MockArchive{}
 			
-			for _, e := range tc.entries {
-				entryPath := e.Path
-				var dst string
+			// Create the actual restorer we want to test
+			r := restorer{
+				logger:                log.NewNopLogger(),
+				a:                     mockArchive,
+				s:                     mockStorage,
+				g:                     generator.NewStatic(tc.key),
+				namespace:             tc.namespace,
+				enableCacheKeySeparator: false,
+			}
+			
+			// Call the actual Restore method
+			err := r.Restore([]string{}, "")
+			if err != nil {
+				t.Fatalf("Error calling Restore: %v", err)
+			}
+			
+			// Wait a reasonable time for all goroutines to complete
+			// This is necessary because Restore launches goroutines to process files
+			time.Sleep(100 * time.Millisecond)
+			
+			// Verify the right paths were processed
+			if len(mockArchive.ExtractCalls) != len(tc.expectedExtractPaths) {
+				t.Errorf("Expected %d extractions, got %d", 
+					len(tc.expectedExtractPaths), len(mockArchive.ExtractCalls))
 				
-				// Try standard trimming first
-				dst = strings.TrimPrefix(entryPath, prefix+"/")
-				
-				// If path wasn't correctly trimmed (prefix didn't match exactly)
-				if strings.HasPrefix(dst, prefix) || strings.Contains(dst, tc.key) {
-					// Extract just the path portion
-					pathComponents := strings.Split(entryPath, "/")
-					
-					// Find the key component
-					keyComponentIndex := -1
-					for i, component := range pathComponents {
-						if strings.Contains(component, tc.key) {
-							keyComponentIndex = i
-						}
-					}
-					
-					// Extract just the path after the key component
-					if keyComponentIndex >= 0 && keyComponentIndex+1 < len(pathComponents) {
-						dst = strings.Join(pathComponents[keyComponentIndex+1:], "/")
-					}
+				// Print details for debugging
+				extractPaths := make([]string, 0, len(mockArchive.ExtractCalls))
+				for _, call := range mockArchive.ExtractCalls {
+					extractPaths = append(extractPaths, call.Dst)
 				}
+				sort.Strings(extractPaths)
 				
-				if dst != "" && strings.Contains(entryPath, tc.key) {
-					dsts = append(dsts, dst)
-					sourcePaths[dst] = entryPath
+				expected := make([]string, len(tc.expectedExtractPaths))
+				copy(expected, tc.expectedExtractPaths)
+				sort.Strings(expected)
+				
+				t.Logf("Expected extract paths: %v", expected)
+				t.Logf("Actual extract paths: %v", extractPaths)
+			}
+			
+			// Verify Get was called with all the expected source paths
+			if len(mockStorage.GetCalls) != len(tc.expectedSourcePaths) {
+				t.Errorf("Expected %d Get calls, got %d", 
+					len(tc.expectedSourcePaths), len(mockStorage.GetCalls))
+				
+				// Print details for debugging
+				sort.Strings(mockStorage.GetCalls)
+				
+				expected := make([]string, len(tc.expectedSourcePaths))
+				copy(expected, tc.expectedSourcePaths)
+				sort.Strings(expected)
+				
+				t.Logf("Expected source paths: %v", expected)
+				t.Logf("Actual Get calls: %v", mockStorage.GetCalls)
+			}
+			
+			// Check each expected extraction path was processed
+			extractPaths := make(map[string]bool)
+			for _, call := range mockArchive.ExtractCalls {
+				extractPaths[call.Dst] = true
+			}
+			
+			for _, expectedPath := range tc.expectedExtractPaths {
+				if !extractPaths[expectedPath] {
+					t.Errorf("Expected path '%s' was not extracted", expectedPath)
 				}
 			}
 			
-			// Sort paths for deterministic comparison
-			sort.Strings(dsts)
-			expectedPaths := make([]string, len(tc.expectedPaths))
-			copy(expectedPaths, tc.expectedPaths)
-			sort.Strings(expectedPaths)
-			
-			// Verify we found the right number of paths
-			if len(dsts) != len(expectedPaths) {
-				t.Errorf("Expected to find %d paths, got %d", len(expectedPaths), len(dsts))
-				t.Logf("Expected: %v", expectedPaths)
-				t.Logf("Actual: %v", dsts)
+			// Check each expected source path was retrieved
+			getCalls := make(map[string]bool)
+			for _, path := range mockStorage.GetCalls {
+				getCalls[path] = true
 			}
 			
-			// Verify each path matches
-			for i, dst := range dsts {
-				if i >= len(expectedPaths) {
-					t.Errorf("Extra path found: %s", dst)
-					continue
-				}
-				
-				expectedDst := expectedPaths[i]
-				if dst != expectedDst {
-					t.Errorf("Path %d: expected '%s', got '%s'", i, expectedDst, dst)
-				}
-				
-				// Check source path mapping
-				expectedSrc, ok := tc.expectedSourcePaths[dst]
-				if !ok {
-					t.Errorf("No expected source path for destination '%s'", dst)
-				} else if expectedSrc != sourcePaths[dst] {
-					t.Errorf("For path '%s', expected source '%s', got '%s'", 
-						dst, expectedSrc, sourcePaths[dst])
+			for _, expectedPath := range tc.expectedSourcePaths {
+				if !getCalls[expectedPath] {
+					t.Errorf("Expected source path '%s' was not retrieved", expectedPath)
 				}
 			}
 		})
+	}
+}
+
+// This test specifically validates our fix for handling key patterns
+func TestFlexibleKeyMatchingRestoration(t *testing.T) {
+	// Test case that simulates the real-world scenario
+	const namespace = "repo"
+	const partialKey = "keypattern"
+	
+	entries := []common.FileEntry{
+		{Path: "repo/keypattern1/path1"},
+		{Path: "repo/keypattern-2/path2"},
+		{Path: "repo/keypattern_3/path3"},
+		{Path: "repo/keypatternSuffix/path4"},
+		{Path: "repo/unrelated/path5"},
+	}
+	
+	// Expected extraction paths - just the paths without the key portion
+	expectedPaths := []string{"path1", "path2", "path3", "path4"}
+	
+	// Setup mocks
+	mockStorage := &MockStorage{
+		ListFunc: func(p string) ([]common.FileEntry, error) {
+			return entries, nil
+		},
+	}
+	
+	mockArchive := &MockArchive{}
+	
+	// Create restorer with the partial key
+	r := restorer{
+		logger:                log.NewNopLogger(),
+		a:                     mockArchive,
+		s:                     mockStorage,
+		g:                     generator.NewStatic(partialKey),
+		namespace:             namespace,
+		enableCacheKeySeparator: false,
+	}
+	
+	// Call Restore
+	err := r.Restore([]string{}, "")
+	if err != nil {
+		t.Fatalf("Error calling Restore: %v", err)
+	}
+	
+	// Wait a reasonable time for all goroutines to complete
+	time.Sleep(100 * time.Millisecond)
+	
+	// Check that only the expected paths were extracted
+	if len(mockArchive.ExtractCalls) != len(expectedPaths) {
+		t.Errorf("Expected %d extractions, got %d", 
+			len(expectedPaths), len(mockArchive.ExtractCalls))
+		
+		var extractedPaths []string
+		for _, call := range mockArchive.ExtractCalls {
+			extractedPaths = append(extractedPaths, call.Dst)
+		}
+		t.Logf("Expected paths: %v", expectedPaths)
+		t.Logf("Actual paths: %v", extractedPaths)
+	}
+	
+	// Verify each path was correctly extracted
+	pathsProcessed := make(map[string]bool)
+	for _, call := range mockArchive.ExtractCalls {
+		pathsProcessed[call.Dst] = true
+	}
+	
+	for _, expected := range expectedPaths {
+		if !pathsProcessed[expected] {
+			t.Errorf("Expected path '%s' was not processed", expected)
+		}
+	}
+	
+	// Check we didn't process the unrelated path
+	if pathsProcessed["path5"] {
+		t.Error("Unrelated path 'path5' was incorrectly processed")
 	}
 }

--- a/internal/plugin/config.go
+++ b/internal/plugin/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	CompressionLevel           int
 	StorageOperationTimeout    time.Duration
 	EnableCacheKeySeparator    bool
+	StrictKeyMatching          bool `envconfig:"PLUGIN_STRICT_KEY_MATCHING" default:"true"`
 
 	Mount []string
 

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -166,7 +166,9 @@ func (p *Plugin) Exec() error { // nolint:funlen
 	}
 
 	options = append(options, cache.WithOverride(p.Config.Override),
-		cache.WithFailRestoreIfKeyNotPresent(p.Config.FailRestoreIfKeyNotPresent), cache.WithEnableCacheKeySeparator(p.Config.EnableCacheKeySeparator))
+		cache.WithFailRestoreIfKeyNotPresent(p.Config.FailRestoreIfKeyNotPresent), 
+		cache.WithEnableCacheKeySeparator(p.Config.EnableCacheKeySeparator),
+		cache.WithStrictKeyMatching(p.Config.StrictKeyMatching))
 
 	// 2. Initialize storage backend.
 	b, err := backend.FromConfig(p.logger, cfg.Backend, backend.Config{

--- a/main.go
+++ b/main.go
@@ -337,6 +337,12 @@ func main() {
 			Value:   false,
 			EnvVars: []string{"PLUGIN_ENABLE_SEPARATOR"},
 		},
+		&cli.BoolFlag{
+			Name:    "strict-key-matching",
+			Usage:   "Strictly match cache keys to avoid prefix collisions (defaults to true)",
+			Value:   true,
+			EnvVars: []string{"PLUGIN_STRICT_KEY_MATCHING"},
+		},
 
 		// Backends Configs
 
@@ -659,6 +665,7 @@ func run(c *cli.Context) error {
 		Override:                   c.Bool("override"),
 		FailRestoreIfKeyNotPresent: c.Bool("fail-restore-if-key-not-present"),
 		EnableCacheKeySeparator:    c.Bool("enable-cache-key-separator"),
+		StrictKeyMatching:          c.Bool("strict-key-matching"),
 
 		StorageOperationTimeout: c.Duration("backend.operation-timeout"),
 		FileSystem: filesystem.Config{


### PR DESCRIPTION
Cache restoration can fail when multiple cache entries exist with keys that share a common prefix (e.g., `project-key-1`, `project-key-2`). This causes path construction inconsistencies and restoration errors, leading to intermittent pipeline failures.
When a user requested to restore a cache with a partial key (e.g., `keypattern` instead of the exact `keypattern-1`), the plugin would correctly identify all matching cache entries but would incorrectly construct the destination paths. This resulted in cache files being restored to unexpected locations, often including part of the key name in the destination path.

For example, when cache entries had keys like:
- `namespace/keypattern-1/path1`
- `namespace/keypattern-2/path2`

And the user requested to restore using just `keypattern`, the paths would be incorrectly constructed.

#### Solution

  - New Flag: `PLUGIN_STRICT_KEY_MATCHING` (default: true)
    - Strict Mode (Default): Only restores from exact key matches, preserving the existing behavior for backward compatibility
    - Flexible Mode: When set to false, the plugin processes all entries with keys that start with the specified prefix
  - Functions correctly with both `enableCacheKeySeparator=true` and `false` settings

#### Testing
- Save Cache:
    - Keys created op-key-1 , op-key-2, op-key-3, op-key-4 [LINK](https://app.harness.io/ng/account/X5kYUmu1Quyqa127CMBb2A/all/orgs/default/projects/CIrepro/pipelines/opCI17216cacherestorepathissuekeypattern/executions/oPKMlYnyTZancExsSJsN0A/pipeline)
- Restore Cache:
    - Partial Key op-key with separator false (default) [LINK](https://app.harness.io/ng/account/X5kYUmu1Quyqa127CMBb2A/all/orgs/default/projects/CIrepro/pipelines/opCI17216cacherestorefinal/executions/7H5TiX4oQPC5OH1i1UMOUA/pipeline?step=DV3d6FJ6Q1y8uvF2NcpzaA&stage=PegS_HPkRaOq1hohOOVFkA&childStage=&stageExecId=)
    - Partial Key op-key with separator true [LINK](https://app.harness.io/ng/account/X5kYUmu1Quyqa127CMBb2A/all/orgs/default/projects/CIrepro/pipelines/opCI17216cacherestorefinal/executions/ag9KoEYJSv27qIDaKhAzQg/pipeline?step=T4HlV2auTSas2Lfl9OeMPA&stage=eX7bGF-4SECUYpSSPmtRgw&childStage=&stageExecId=)
    - Exact key op-key-4 with separator false (default) [LINK](https://app.harness.io/ng/account/X5kYUmu1Quyqa127CMBb2A/all/orgs/default/projects/CIrepro/pipelines/opCI17216cacherestorefinal/executions/A75-DW0tRZu4Uod8xo4DZA/pipeline?step=rFp_QNtBTXib32nN_bDpEA&stage=CV5rdgNcTmGixQVHxmN19g&childStage=&stageExecId=)
    - Exact key op-key-4 with separator true [LINK](https://app.harness.io/ng/account/X5kYUmu1Quyqa127CMBb2A/all/orgs/default/projects/CIrepro/pipelines/opCI17216cacherestorefinal/executions/O8SUUIM3SZ2Qt0rUn2K7EA/pipeline?step=Q0A4M8vzRVuUvZVR25zhsw&stage=Jfyd4lsDSpeGJ_6hyCDjSQ&childStage=&stageExecId=)