### PR TITLE
fix: [CI-18106]: Fix windows case for backward slash

### DIFF
--- a/harness/http.go
+++ b/harness/http.go
@@ -47,13 +47,13 @@ type HTTPClient struct {
 
 // getUploadURL will get the 'put' presigned url from cache service
 func (c *HTTPClient) GetUploadURL(ctx context.Context, key string) (string, error) {
-	path := fmt.Sprintf(StoreEndpoint, c.AccountID, key)
+	path := c.buildEndpointPath(StoreEndpoint, key)
 	return c.getLink(ctx, c.Endpoint+path)
 }
 
 // GetUploadURLWithQuery will get the 'put' presigned url from cache service with additional query parameters
 func (c *HTTPClient) GetUploadURLWithQuery(ctx context.Context, key string, query url.Values) (string, error) {
-	path := fmt.Sprintf(StoreEndpoint, c.AccountID, key)
+	path := c.buildEndpointPath(StoreEndpoint, key)
 	fullURL := c.Endpoint + path
 	if len(query) > 0 {
 		if strings.Contains(fullURL, "?") {
@@ -74,19 +74,19 @@ func (c *HTTPClient) GetUploadURLWithQuery(ctx context.Context, key string, quer
 
 // GetDownloadURL will get the 'get' presigned url from cache service
 func (c *HTTPClient) GetDownloadURL(ctx context.Context, key string) (string, error) {
-	path := fmt.Sprintf(RestoreEndpoint, c.AccountID, key)
+	path := c.buildEndpointPath(RestoreEndpoint, key)
 	return c.getLink(ctx, c.Endpoint+path)
 }
 
 // GetExistsURL will get the 'exists' presigned url from cache service
 func (c *HTTPClient) GetExistsURL(ctx context.Context, key string) (string, error) {
-	path := fmt.Sprintf(ExistsEndpoint, c.AccountID, key)
+	path := c.buildEndpointPath(ExistsEndpoint, key)
 	return c.getLink(ctx, c.Endpoint+path)
 }
 
 // GetListURL will get the list of all entries
 func (c *HTTPClient) GetEntriesList(ctx context.Context, prefix string) ([]common.FileEntry, error) {
-	path := fmt.Sprintf(ListEntriesEndpoint, c.AccountID, prefix)
+	path := c.buildEndpointPath(ListEntriesEndpoint, prefix)
 	req, err := http.NewRequestWithContext(ctx, "GET", c.Endpoint+path, nil)
 	if err != nil {
 		return nil, err
@@ -140,4 +140,12 @@ func (c *HTTPClient) getLink(ctx context.Context, path string) (string, error) {
 
 func (c *HTTPClient) client() *http.Client {
 	return c.Client
+}
+
+// buildEndpointPath constructs a properly formatted and URL-encoded API endpoint path
+// This centralizes the URL encoding of path components to handle Windows backslashes
+func (c *HTTPClient) buildEndpointPath(endpointFormat string, key string) string {
+	// URL encode the key to handle Windows backslashes and other special characters
+	encodedKey := url.QueryEscape(key)
+	return fmt.Sprintf(endpointFormat, c.AccountID, encodedKey)
 }


### PR DESCRIPTION

Reproduced the 503 status in my local terminal if the key has a backslash \ then we are getting 503.  this behaviour is limited to QA. Added a url encode that will encode the \ in the key

<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Thank you for your pull request. Please provide a description above and review
the requirements below.

**BUG FIXES AND NEW FEATURES SHOULD INCLUDE TESTS.**

Contributors guide: ./CONTRIBUTING.md
Code of conduct: ./CODE_OF_CONDUCT.md
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.

Fixes #

## Proposed Changes
<!-- Please briefly list the changes you made here. -->

-
-
-

### Description

<!-- Please explain the changes you made here. -->

### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
