### PR TITLE
fix: apply metadata outside symlink handling

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -378,3 +378,6 @@ encryption
 
 skip_symlinks
 : skip symbolic links in archive
+
+preserve_metadata
+: preserve file permissions, ownership, and timestamps when storing and restoring caches (S3/GCS only)

--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ GLOBAL OPTIONS:
    --archive-format value                archive format to use to store the cache directories (tar, gzip, zstd) (default: "tar") [$PLUGIN_ARCHIVE_FORMAT]
    --compression-level value             compression level to use for gzip/zstd compression when archive-format specified as gzip/zstd
                                              (check https://godoc.org/compress/flate#pkg-constants for available options for gzip
-                                             and https://pkg.go.dev/github.com/klauspost/compress/zstd#EncoderLevelFromZstd for zstd) (default: -1) 
+                                             and https://pkg.go.dev/github.com/klauspost/compress/zstd#EncoderLevelFromZstd for zstd) (default: -1)
    --skip-symlinks                       skip symbolic links in archive (default: false) [$PLUGIN_SKIP_SYMLINKS, $SKIP_SYMLINKS]
+   --preserve-metadata                   preserve file metadata (mode, ownership, timestamps) (default: false) [$PLUGIN_PRESERVE_METADATA]
    --debug                               debug (default: false) [$PLUGIN_DEBUG, $DEBUG]
    --backend.operation-timeout value     timeout value to use for each storage operations (default: 3m0s) [$PLUGIN_BACKEND_OPERATION_TIMEOUT, $BACKEND_OPERATION_TIMEOUT]
    --endpoint value                      endpoint for the s3/cloud storage connection [$PLUGIN_ENDPOINT, $S3_ENDPOINT, $GCS_ENDPOINT]

--- a/archive/archive.go
+++ b/archive/archive.go
@@ -46,13 +46,13 @@ func FromFormat(logger log.Logger, root string, format string, opts ...Option) A
 
 	switch format {
 	case Gzip:
-		return gzip.New(logger, root, options.skipSymlinks, options.compressionLevel)
+		return gzip.New(logger, root, options.skipSymlinks, options.compressionLevel, options.preserveMetadata)
 	case Zstd:
-		return zstd.New(logger, root, options.skipSymlinks, options.compressionLevel)
+		return zstd.New(logger, root, options.skipSymlinks, options.compressionLevel, options.preserveMetadata)
 	case Tar:
-		return tar.New(logger, root, options.skipSymlinks)
+		return tar.New(logger, root, options.skipSymlinks, options.preserveMetadata)
 	default:
 		level.Error(logger).Log("msg", "unknown archive format", "format", format)
-		return tar.New(logger, root, options.skipSymlinks) // DefaultArchiveFormat
+		return tar.New(logger, root, options.skipSymlinks, options.preserveMetadata) // DefaultArchiveFormat
 	}
 }

--- a/archive/gzip/gzip.go
+++ b/archive/gzip/gzip.go
@@ -18,11 +18,12 @@ type Archive struct {
 	root             string
 	compressionLevel int
 	skipSymlinks     bool
+	preserveMetadata bool
 }
 
 // New creates an archive that uses the .tar.gz file format.
-func New(logger log.Logger, root string, skipSymlinks bool, compressionLevel int) *Archive {
-	return &Archive{logger, root, compressionLevel, skipSymlinks}
+func New(logger log.Logger, root string, skipSymlinks bool, compressionLevel int, preserveMetadata bool) *Archive {
+	return &Archive{logger, root, compressionLevel, skipSymlinks, preserveMetadata}
 }
 
 // Create writes content of the given source to an archive, returns written bytes.
@@ -36,7 +37,7 @@ func (a *Archive) Create(srcs []string, w io.Writer, isRelativePath bool) (int64
 
 	defer internal.CloseWithErrLogf(a.logger, gw, "gzip writer")
 
-	return tar.New(a.logger, a.root, a.skipSymlinks).Create(srcs, gw, isRelativePath)
+	return tar.New(a.logger, a.root, a.skipSymlinks, a.preserveMetadata).Create(srcs, gw, isRelativePath)
 }
 
 // Extract reads content from the given archive reader and restores it to the destination, returns written bytes.
@@ -48,5 +49,5 @@ func (a *Archive) Extract(dst string, r io.Reader) (int64, error) {
 
 	defer internal.CloseWithErrLogf(a.logger, gr, "gzip reader")
 
-	return tar.New(a.logger, a.root, a.skipSymlinks).Extract(dst, gr)
+	return tar.New(a.logger, a.root, a.skipSymlinks, a.preserveMetadata).Extract(dst, gr)
 }

--- a/archive/gzip/gzip_test.go
+++ b/archive/gzip/gzip_test.go
@@ -45,14 +45,14 @@ func TestCreate(t *testing.T) {
 	}{
 		{
 			name:    "empty mount paths",
-			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs:    []string{},
 			written: 0,
 			err:     nil,
 		},
 		{
 			name: "non-existing mount paths",
-			tgz:  New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:  New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs: []string{
 				"iamnotexists",
 				"metoo",
@@ -62,28 +62,28 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			name:    "existing mount paths",
-			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs:    exampleFileTree(t, "gzip_create", testRootMounted),
 			written: 43, // 3 x tmpfile in dir, 1 tmpfile
 			err:     nil,
 		},
 		{
 			name:    "existing mount nested paths",
-			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs:    exampleNestedFileTree(t, "tar_create"),
 			written: 56, // 4 x tmpfile in dir, 1 tmpfile
 			err:     nil,
 		},
 		{
 			name:    "existing mount paths with symbolic links",
-			tgz:     New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression),
+			tgz:     New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression, false),
 			srcs:    exampleFileTreeWithSymlinks(t, "gzip_create_symlink"),
 			written: 43,
 			err:     nil,
 		},
 		{
 			name:    "absolute mount paths",
-			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:     New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs:    exampleFileTree(t, "tar_create", testAbs),
 			written: 43,
 			err:     nil,
@@ -151,7 +151,7 @@ func TestExtract(t *testing.T) {
 	})
 
 	// Setup
-	tgz := New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression)
+	tgz := New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression, false)
 
 	arcDir, arcDirClean := test.CreateTempDir(t, "gzip_extract_archive")
 	t.Cleanup(arcDirClean)
@@ -193,7 +193,7 @@ func TestExtract(t *testing.T) {
 	}{
 		{
 			name:        "non-existing archive",
-			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: "iamnotexists",
 			srcs:        []string{},
 			written:     0,
@@ -201,7 +201,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "non-existing root destination",
-			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: emptyArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -209,7 +209,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "empty archive",
-			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: emptyArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -217,7 +217,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "bad archives",
-			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: badArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -225,7 +225,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive",
-			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: archivePath,
 			srcs:        files,
 			written:     43,
@@ -233,7 +233,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive with nested files",
-			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: nestedArchivePath,
 			srcs:        nestedFiles,
 			written:     56,
@@ -241,7 +241,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive with symbolic links",
-			tgz:         New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression),
+			tgz:         New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression, false),
 			archivePath: archiveWithSymlinkPath,
 			srcs:        filesWithSymlink,
 			written:     43,
@@ -249,7 +249,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "absolute mount paths",
-			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tgz:         New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: archiveAbsPath,
 			srcs:        filesAbs,
 			written:     43,

--- a/archive/option.go
+++ b/archive/option.go
@@ -3,6 +3,7 @@ package archive
 type options struct {
 	compressionLevel int
 	skipSymlinks     bool
+	preserveMetadata bool
 }
 
 // Option overrides behavior of Archive.
@@ -27,5 +28,12 @@ func WithCompressionLevel(i int) Option {
 func WithSkipSymlinks(b bool) Option {
 	return optionFunc(func(o *options) {
 		o.skipSymlinks = b
+	})
+}
+
+// WithPreserveMetadata sets preserve metadata option.
+func WithPreserveMetadata(b bool) Option {
+	return optionFunc(func(o *options) {
+		o.preserveMetadata = b
 	})
 }

--- a/archive/tar/chown_unix.go
+++ b/archive/tar/chown_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package tar
+
+import "os"
+
+func chown(path string, uid, gid int) error {
+	return os.Chown(path, uid, gid)
+}
+
+func lchown(path string, uid, gid int) error {
+	return os.Lchown(path, uid, gid)
+}

--- a/archive/tar/chown_windows.go
+++ b/archive/tar/chown_windows.go
@@ -1,0 +1,6 @@
+//go:build windows
+
+package tar
+
+func chown(path string, uid, gid int) error  { return nil }
+func lchown(path string, uid, gid int) error { return nil }

--- a/archive/tar/metadata_test.go
+++ b/archive/tar/metadata_test.go
@@ -1,0 +1,63 @@
+package tar
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/meltwater/drone-cache/test"
+)
+
+func TestExtractPreserveMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows metadata semantics differ")
+	}
+	src := t.TempDir()
+	filePath := filepath.Join(src, "file.txt")
+	data := []byte("hello")
+	test.Ok(t, os.WriteFile(filePath, data, 0640))
+	mtime := time.Now().Add(-1 * time.Hour).Truncate(time.Second)
+	test.Ok(t, os.Chtimes(filePath, mtime, mtime))
+
+	buf := new(bytes.Buffer)
+	cwd, _ := os.Getwd()
+	test.Ok(t, os.Chdir(src))
+	_, err := New(log.NewNopLogger(), "", false, true).Create([]string{"file.txt"}, buf, true)
+	test.Ok(t, os.Chdir(cwd))
+	test.Ok(t, err)
+
+	dst := t.TempDir()
+	test.Ok(t, os.Chdir(dst))
+	_, err = New(log.NewNopLogger(), "", false, true).Extract("", bytes.NewReader(buf.Bytes()))
+	test.Ok(t, err)
+	test.Ok(t, os.Chdir(cwd))
+
+	extracted := filepath.Join(dst, "file.txt")
+	fi, err := os.Stat(extracted)
+	test.Ok(t, err)
+	test.Equals(t, os.FileMode(0640), fi.Mode().Perm())
+	test.Equals(t, mtime, fi.ModTime())
+}
+
+func TestExtractPreserveMetadata_OldArchiveGraceful(t *testing.T) {
+	src := t.TempDir()
+	filePath := filepath.Join(src, "file.txt")
+	test.Ok(t, os.WriteFile(filePath, []byte("hi"), 0644))
+	buf := new(bytes.Buffer)
+	cwd, _ := os.Getwd()
+	test.Ok(t, os.Chdir(src))
+	_, err := New(log.NewNopLogger(), "", false, false).Create([]string{"file.txt"}, buf, true)
+	test.Ok(t, os.Chdir(cwd))
+	test.Ok(t, err)
+
+	dst := t.TempDir()
+	test.Ok(t, os.Chdir(dst))
+	_, err = New(log.NewNopLogger(), "", false, true).Extract("", bytes.NewReader(buf.Bytes()))
+	test.Ok(t, err)
+	test.Ok(t, os.Chdir(cwd))
+	test.Exists(t, filepath.Join(dst, "file.txt"))
+}

--- a/archive/tar/metadata_unix.go
+++ b/archive/tar/metadata_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package tar
+
+import (
+	"archive/tar"
+	"os"
+	"syscall"
+	"time"
+)
+
+func applyHeaderMetadata(fi os.FileInfo, h *tar.Header) {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return
+	}
+	h.Uid = int(st.Uid)
+	h.Gid = int(st.Gid)
+	atime := time.Unix(int64(st.Atim.Sec), int64(st.Atim.Nsec))
+	h.AccessTime = atime
+	ctime := time.Unix(int64(st.Ctim.Sec), int64(st.Ctim.Nsec))
+	h.ChangeTime = ctime
+}

--- a/archive/tar/metadata_windows.go
+++ b/archive/tar/metadata_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package tar
+
+import (
+	"archive/tar"
+	"os"
+)
+
+func applyHeaderMetadata(fi os.FileInfo, h *tar.Header) {}

--- a/archive/tar/tar_test.go
+++ b/archive/tar/tar_test.go
@@ -42,14 +42,14 @@ func TestCreate(t *testing.T) {
 	}{
 		{
 			name:    "empty mount paths",
-			ta:      New(log.NewNopLogger(), testRootMounted, true),
+			ta:      New(log.NewNopLogger(), testRootMounted, true, false),
 			srcs:    []string{},
 			written: 0,
 			err:     nil,
 		},
 		{
 			name: "non-existing mount paths",
-			ta:   New(log.NewNopLogger(), testRootMounted, true),
+			ta:   New(log.NewNopLogger(), testRootMounted, true, false),
 			srcs: []string{
 				"idonotexist",
 				"metoo",
@@ -59,28 +59,28 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			name:    "existing mount paths",
-			ta:      New(log.NewNopLogger(), testRootMounted, true),
+			ta:      New(log.NewNopLogger(), testRootMounted, true, false),
 			srcs:    exampleFileTree(t, "tar_create", testRootMounted),
 			written: 43, // 3 x tmpfile in dir, 1 tmpfile
 			err:     nil,
 		},
 		{
 			name:    "existing mount nested paths",
-			ta:      New(log.NewNopLogger(), testRootMounted, true),
+			ta:      New(log.NewNopLogger(), testRootMounted, true, false),
 			srcs:    exampleNestedFileTree(t, "tar_create"),
 			written: 56, // 4 x tmpfile in dir, 1 tmpfile
 			err:     nil,
 		},
 		{
 			name:    "existing mount paths with symbolic links",
-			ta:      New(log.NewNopLogger(), testRootMounted, false),
+			ta:      New(log.NewNopLogger(), testRootMounted, false, false),
 			srcs:    exampleFileTreeWithSymlinks(t, "tar_create_symlink"),
 			written: 43,
 			err:     nil,
 		},
 		{
 			name:    "absolute mount paths",
-			ta:      New(log.NewNopLogger(), testRootMounted, true),
+			ta:      New(log.NewNopLogger(), testRootMounted, true, false),
 			srcs:    exampleFileTree(t, "tar_create", testAbs),
 			written: 43,
 			err:     nil,
@@ -150,7 +150,7 @@ func TestExtract(t *testing.T) {
 	})
 
 	// Setup
-	ta := New(log.NewNopLogger(), testRootMounted, false)
+	ta := New(log.NewNopLogger(), testRootMounted, false, false)
 
 	arcDir, arcDirClean := test.CreateTempDir(t, "tar_extract_archives", testRootMounted)
 	t.Cleanup(arcDirClean)
@@ -197,7 +197,7 @@ func TestExtract(t *testing.T) {
 	}{
 		{
 			name:        "non-existing archive",
-			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			ta:          New(log.NewNopLogger(), testRootMounted, false, false),
 			archivePath: "idonotexist",
 			srcs:        []string{},
 			written:     0,
@@ -205,7 +205,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "non-existing root destination",
-			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			ta:          New(log.NewNopLogger(), testRootMounted, false, false),
 			archivePath: emptyArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -213,7 +213,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "empty archive",
-			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			ta:          New(log.NewNopLogger(), testRootMounted, false, false),
 			archivePath: emptyArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -221,7 +221,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "bad archives",
-			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			ta:          New(log.NewNopLogger(), testRootMounted, false, false),
 			archivePath: badArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -229,7 +229,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive",
-			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			ta:          New(log.NewNopLogger(), testRootMounted, false, false),
 			archivePath: archivePath,
 			srcs:        files,
 			written:     43,
@@ -237,7 +237,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive with nested files",
-			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			ta:          New(log.NewNopLogger(), testRootMounted, false, false),
 			archivePath: nestedArchivePath,
 			srcs:        nestedFiles,
 			written:     56,
@@ -245,7 +245,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive with symbolic links",
-			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			ta:          New(log.NewNopLogger(), testRootMounted, false, false),
 			archivePath: archiveWithSymlinkPath,
 			srcs:        filesWithSymlink,
 			written:     43,
@@ -253,7 +253,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive with hidden symbolic links",
-			ta:          New(log.NewNopLogger(), testRootMounted, false),
+			ta:          New(log.NewNopLogger(), testRootMounted, false, false),
 			archivePath: archiveWithSymlinkHiddenPath,
 			srcs:        filesWithSymlinkHidden,
 			written:     43,
@@ -261,7 +261,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "absolute mount paths",
-			ta:          New(log.NewNopLogger(), testRootMounted, true),
+			ta:          New(log.NewNopLogger(), testRootMounted, true, false),
 			archivePath: archiveAbsPath,
 			srcs:        filesAbs,
 			written:     43,

--- a/archive/zstd/zstd.go
+++ b/archive/zstd/zstd.go
@@ -17,11 +17,12 @@ type Archive struct {
 	root             string
 	compressionLevel int
 	skipSymlinks     bool
+	preserveMetadata bool
 }
 
 // New creates an archive that uses the .tar.zst file format.
-func New(logger log.Logger, root string, skipSymlinks bool, compressionLevel int) *Archive {
-	return &Archive{logger, root, compressionLevel, skipSymlinks}
+func New(logger log.Logger, root string, skipSymlinks bool, compressionLevel int, preserveMetadata bool) *Archive {
+	return &Archive{logger, root, compressionLevel, skipSymlinks, preserveMetadata}
 }
 
 // Create writes content of the given source to an archive, returns written bytes.
@@ -37,7 +38,7 @@ func (a *Archive) Create(srcs []string, w io.Writer, isRelativePath bool) (int64
 
 	defer internal.CloseWithErrLogf(a.logger, zw, "zstd writer")
 
-	wBytes, err := tar.New(a.logger, a.root, a.skipSymlinks).Create(srcs, zw, isRelativePath)
+	wBytes, err := tar.New(a.logger, a.root, a.skipSymlinks, a.preserveMetadata).Create(srcs, zw, isRelativePath)
 	if err != nil {
 		return 0, fmt.Errorf("zstd create archive, %w", err)
 	}
@@ -54,7 +55,7 @@ func (a *Archive) Extract(dst string, r io.Reader) (int64, error) {
 
 	defer internal.CloseWithErrLogf(a.logger, zr.IOReadCloser(), "zstd reader")
 
-	eBytes, err := tar.New(a.logger, a.root, a.skipSymlinks).Extract(dst, zr)
+	eBytes, err := tar.New(a.logger, a.root, a.skipSymlinks, a.preserveMetadata).Extract(dst, zr)
 	if err != nil {
 		return 0, fmt.Errorf("zstd extract archive, %w", err)
 	}

--- a/archive/zstd/zstd_test.go
+++ b/archive/zstd/zstd_test.go
@@ -34,14 +34,14 @@ func TestCreate(t *testing.T) {
 	}{
 		{
 			name:    "empty mount paths",
-			tzst:    New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:    New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs:    []string{},
 			written: 0,
 			err:     nil,
 		},
 		{
 			name: "non-existing mount paths",
-			tzst: New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst: New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs: []string{
 				"iamnotexists",
 				"metoo",
@@ -51,21 +51,21 @@ func TestCreate(t *testing.T) {
 		},
 		{
 			name:    "existing mount paths",
-			tzst:    New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:    New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs:    exampleFileTree(t, "zstd_create"),
 			written: 43, // 3 x tmpfile in dir, 1 tmpfile
 			err:     nil,
 		},
 		{
 			name:    "existing mount nested paths",
-			tzst:    New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:    New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			srcs:    exampleNestedFileTree(t, "tar_create"),
 			written: 56, // 4 x tmpfile in dir, 1 tmpfile
 			err:     nil,
 		},
 		{
 			name:    "existing mount paths with symbolic links",
-			tzst:    New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression),
+			tzst:    New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression, false),
 			srcs:    exampleFileTreeWithSymlinks(t, "zstd_create_symlink"),
 			written: 43,
 			err:     nil,
@@ -106,7 +106,7 @@ func TestExtract(t *testing.T) {
 	t.Cleanup(func() { os.RemoveAll(testRoot) })
 
 	// Setup
-	tzst := New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression)
+	tzst := New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression, false)
 
 	arcDir, arcDirClean := test.CreateTempDir(t, "zstd_extract_archive")
 	t.Cleanup(arcDirClean)
@@ -143,7 +143,7 @@ func TestExtract(t *testing.T) {
 	}{
 		{
 			name:        "non-existing archive",
-			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: "iamnotexists",
 			srcs:        []string{},
 			written:     0,
@@ -151,7 +151,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "non-existing root destination",
-			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: emptyArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -159,7 +159,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "empty archive",
-			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: emptyArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -167,7 +167,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "bad archives",
-			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: badArchivePath,
 			srcs:        []string{},
 			written:     0,
@@ -175,7 +175,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive",
-			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: archivePath,
 			srcs:        files,
 			written:     43,
@@ -183,7 +183,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive with nested files",
-			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression),
+			tzst:        New(log.NewNopLogger(), testRootMounted, true, flate.DefaultCompression, false),
 			archivePath: nestedArchivePath,
 			srcs:        nestedFiles,
 			written:     56,
@@ -191,7 +191,7 @@ func TestExtract(t *testing.T) {
 		},
 		{
 			name:        "existing archive with symbolic links",
-			tzst:        New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression),
+			tzst:        New(log.NewNopLogger(), testRootMounted, false, flate.DefaultCompression, false),
 			archivePath: archiveWithSymlinkPath,
 			srcs:        filesWithSymlink,
 			written:     43,

--- a/internal/plugin/config.go
+++ b/internal/plugin/config.go
@@ -30,6 +30,7 @@ type Config struct {
 
 	// Optional
 	SkipSymlinks               bool
+	PreserveMetadata           bool
 	Override                   bool
 	FailRestoreIfKeyNotPresent bool
 	CompressionLevel           int

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -166,7 +166,7 @@ func (p *Plugin) Exec() error { // nolint:funlen
 	}
 
 	options = append(options, cache.WithOverride(p.Config.Override),
-		cache.WithFailRestoreIfKeyNotPresent(p.Config.FailRestoreIfKeyNotPresent), 
+		cache.WithFailRestoreIfKeyNotPresent(p.Config.FailRestoreIfKeyNotPresent),
 		cache.WithEnableCacheKeySeparator(p.Config.EnableCacheKeySeparator),
 		cache.WithStrictKeyMatching(p.Config.StrictKeyMatching))
 
@@ -190,6 +190,7 @@ func (p *Plugin) Exec() error { // nolint:funlen
 		archive.FromFormat(p.logger, localRoot, cfg.ArchiveFormat,
 			archive.WithSkipSymlinks(cfg.SkipSymlinks),
 			archive.WithCompressionLevel(cfg.CompressionLevel),
+			archive.WithPreserveMetadata(cfg.PreserveMetadata && (cfg.Backend == backend.S3 || cfg.Backend == backend.GCS)),
 		),
 		generator,
 		cfg.Backend,

--- a/main.go
+++ b/main.go
@@ -314,6 +314,11 @@ func main() {
 			EnvVars: []string{"PLUGIN_SKIP_SYMLINKS", "SKIP_SYMLINKS"},
 		},
 		&cli.BoolFlag{
+			Name:    "preserve-metadata",
+			Usage:   "preserve file metadata (mode, ownership, timestamps)",
+			EnvVars: []string{"PLUGIN_PRESERVE_METADATA"},
+		},
+		&cli.BoolFlag{
 			Name:    "debug, d",
 			Usage:   "debug",
 			EnvVars: []string{"PLUGIN_DEBUG", "DEBUG"},
@@ -731,7 +736,8 @@ func run(c *cli.Context) error {
 			MultipartEnabled:       c.String("multipart.enabled"),
 		},
 
-		SkipSymlinks: c.Bool("skip-symlinks"),
+		SkipSymlinks:     c.Bool("skip-symlinks"),
+		PreserveMetadata: c.Bool("preserve-metadata"),
 	}
 
 	err := plg.Exec()


### PR DESCRIPTION
Jira: https://harness.atlassian.net/browse/CI-18276?focusedCommentId=1217420

This PR addresses a critical issue where the Harness CI cache plugin fails to preserve file timestamps when restoring caches from S3 or GCS. This bug prevents time-based cleanup mechanisms, like Gradle's built-in pruning and standard find commands, from correctly identifying and deleting old cache files.

The fix introduces a new, optional boolean flag, preserve_metadata, which defaults to false for backward compatibility. When set to true, the plugin will now explicitly restore the original file timestamps upon extracting the cache to the build agent.

Key changes:

New Flag: preserve_metadata is added to the plugin settings.

Core Logic: The plugin will now restore file timestamps to their original values.

Scope: This fix applies to the S3 and GCS backends of the drone-cache plugin.

Acceptance Criteria: After this change, time-based cache cleanup will function correctly, ensuring that old files are properly removed to save disk space.

This enhancement is crucial for ensuring the efficiency and health of build agent disk space over time.


Executions:
S3
linux k8s: [https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]pUPZp3rkw&step=whCLcek2SMuCX3MqLgcWLQ&childStage=&stageExecId=](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/S3Test/executions/_kMtRrN1QGuwo8UC7hvC1w/pipeline?stage=tKpeGeyfRCmgspUPZp3rkw&step=whCLcek2SMuCX3MqLgcWLQ&childStage=&stageExecId=)
linux amd64 hosted:
[https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]1MDTygs4g&step=dfb1JTzcTHqCXcNAG8K54w&childStage=&stageExecId=](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/S3Test/executions/fh9h3zxESlm09yzyRn0fgg/pipeline?stage=AHX-y982RZi8V1MDTygs4g&step=dfb1JTzcTHqCXcNAG8K54w&childStage=&stageExecId=)
linux arm64 hosted:
[https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]iIGiPhZTA&step=VwLtHBo2SoiIMabgltI0IA&childStage=&stageExecId=](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/S3Test/executions/WMrhSjAwRRKGKxhv9-LnjA/pipeline?storeType=INLINE&stage=xhTWfXa2QQinMiIGiPhZTA&step=VwLtHBo2SoiIMabgltI0IA&childStage=&stageExecId=)
windows amd64 hosted:
[https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]Y6rC-JcSg&step=GWAuWMkVRlWi25QNkoLNEA&childStage=&stageExecId=](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/S3Test/executions/mvBY2V0LQQ239MVHjo_jqQ/pipeline?stage=gtNLt86aQnO0QY6rC-JcSg&step=GWAuWMkVRlWi25QNkoLNEA&childStage=&stageExecId=)
GCS
linux amd k8:
[https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]s/HIB37_VXQxuqu32T1KN02w/pipeline?stage=fxJ4nGhOSVGR7AwmVhXyBw](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/GCS_Test_Hosted/executions/HIB37_VXQxuqu32T1KN02w/pipeline?stage=fxJ4nGhOSVGR7AwmVhXyBw)
linux amd64 hosted:
[https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]s/QQDhNZTgRoCu8J1vvi2Hpw/pipeline?stage=joHCSxrDRseWKIRWS6HfEQ](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/GCS_Test_Hosted/executions/QQDhNZTgRoCu8J1vvi2Hpw/pipeline?stage=joHCSxrDRseWKIRWS6HfEQ)
linux arm64 hosted:
[https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]s/Leng1b3WRBCxt7KpinNqaA/pipeline?stage=bBDq1S5AQDeQchI0YzL67A](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/GCS_Test_Hosted/executions/Leng1b3WRBCxt7KpinNqaA/pipeline?stage=bBDq1S5AQDeQchI0YzL67A)
windows amd64 hosted:
[https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]s/C8scgYOESyCAUJF6xdYXNQ/pipeline?stage=SVHJ1EBiQj2uq1rscpvirw](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/GCS_Test_Hosted/executions/C8scgYOESyCAUJF6xdYXNQ/pipeline?stage=SVHJ1EBiQj2uq1rscpvirw)
disabled:
[https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/V[…]ed/executions/jiTjxCsLS9C_ZOJhCgeakA/pipeline?storeType=INLINE](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/GCS_Test_Hosted/executions/jiTjxCsLS9C_ZOJhCgeakA/pipeline?storeType=INLINE)

Final execution with deletion logic:
https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/GCS_Test_Hosted/executions/6RTWbmiSQyiUnYV71rS2gg/pipeline

without the flag: https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/Vikas/pipelines/GCS_Test_Hosted/executions/TAu-LxlfRK-UYznsAcCHaQ/pipeline

<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Thank you for your pull request. Please provide a description above and review
the requirements below.

**BUG FIXES AND NEW FEATURES SHOULD INCLUDE TESTS.**

Contributors guide: ./CONTRIBUTING.md
Code of conduct: ./CODE_OF_CONDUCT.md
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.

Fixes #

## Proposed Changes
<!-- Please briefly list the changes you made here. -->

-
-
-

### Description

<!-- Please explain the changes you made here. -->

### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
