### PR TITLE
fix: [CI-20023]: fixed the remote storage path for the docker infra

### DIFF
--- a/cache/rebuilder.go
+++ b/cache/rebuilder.go
@@ -37,6 +37,37 @@ func NewRebuilder(logger log.Logger, s storage.Storage, a archive.Archive, g key
 	return rebuilder{logger, a, s, g, fg, namespace, override, gracefulDetect}
 }
 
+// normalizeDockerPath converts Docker infrastructure paths to a fixed format.
+// When DRONE_STAGE_TYPE=DOCKER, paths like /tmp/harness/<uuid>/...
+// are converted to docker/... for consistent remote storage keys.
+func normalizeDockerPath(src string) string {
+	if os.Getenv("DRONE_STAGE_TYPE") != "DOCKER" {
+		return src
+	}
+
+	normalizedPath := filepath.ToSlash(src)
+	const unixPrefix = "/tmp/harness/"
+	const windowsPrefix = "C:/tmp/harness/"
+
+	var remainder string
+	if strings.HasPrefix(normalizedPath, unixPrefix) {
+		remainder = strings.TrimPrefix(normalizedPath, unixPrefix)
+	} else if strings.HasPrefix(normalizedPath, windowsPrefix) {
+		remainder = strings.TrimPrefix(normalizedPath, windowsPrefix)
+	} else {
+		return src
+	}
+
+	// Find the UUID segment and skip it
+	idx := strings.Index(remainder, "/")
+	if idx == -1 {
+		return src
+	}
+
+	// Return fixed prefix + relative path
+	return filepath.Join("docker", remainder[idx+1:])
+}
+
 // Rebuild rebuilds cache from the files provided with given paths.
 func (r rebuilder) Rebuild(srcs []string) error {
 	level.Info(r.logger).Log("msg", "rebuilding cache")
@@ -64,7 +95,8 @@ func (r rebuilder) Rebuild(srcs []string) error {
 			level.Warn(r.logger).Log("msg", fmt.Sprintf("source directory %s does not exist", src), "err", fmt.Errorf("source <%s>, make sure file or directory exists and readable, %w", src, err))
 		}
 
-		dst := filepath.Join(namespace, key, src)
+		normalizedSrc := normalizeDockerPath(src)
+		dst := filepath.Join(namespace, key, normalizedSrc)
 
 		// If no override is set and object already exists in storage, skip it.
 		if !r.override {

--- a/cache/rebuilder_test.go
+++ b/cache/rebuilder_test.go
@@ -1,8 +1,85 @@
 package cache
 
-import "testing"
+import (
+	"os"
+	"testing"
+)
 
 func TestRebuild(t *testing.T) {
 	// Implement me!
 	t.Skip("skipping unimplemented test.")
+}
+
+func TestNormalizeDockerPath(t *testing.T) {
+	tests := []struct {
+		name      string
+		stageType string
+		input     string
+		expected  string
+	}{
+		{
+			name:      "non-docker env returns input unchanged",
+			stageType: "",
+			input:     "/tmp/harness/uuid-abc123/.gradle",
+			expected:  "/tmp/harness/uuid-abc123/.gradle",
+		},
+		{
+			name:      "docker env with unix harness path",
+			stageType: "DOCKER",
+			input:     "/tmp/harness/uuid-abc123/.gradle",
+			expected:  "docker/.gradle",
+		},
+		{
+			name:      "docker env with nested unix path",
+			stageType: "DOCKER",
+			input:     "/tmp/harness/NsisF6Y9QfaOtdukTItZfA/.gradle/caches/modules-2",
+			expected:  "docker/.gradle/caches/modules-2",
+		},
+		{
+			name:      "docker env with windows harness path",
+			stageType: "DOCKER",
+			input:     "C:/tmp/harness/uuid-abc123/.gradle",
+			expected:  "docker/.gradle",
+		},
+		{
+			name:      "docker env with non-matching prefix returns unchanged",
+			stageType: "DOCKER",
+			input:     "/home/user/.gradle",
+			expected:  "/home/user/.gradle",
+		},
+		{
+			name:      "docker env with no UUID segment returns unchanged",
+			stageType: "DOCKER",
+			input:     "/tmp/harness/nouuidhere",
+			expected:  "/tmp/harness/nouuidhere",
+		},
+		{
+			name:      "docker env with relative path returns unchanged",
+			stageType: "DOCKER",
+			input:     ".gradle",
+			expected:  ".gradle",
+		},
+		{
+			name:      "docker env with only UUID and single file",
+			stageType: "DOCKER",
+			input:     "/tmp/harness/some-uuid/file.txt",
+			expected:  "docker/file.txt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.stageType != "" {
+				os.Setenv("DRONE_STAGE_TYPE", tt.stageType)
+				defer os.Unsetenv("DRONE_STAGE_TYPE")
+			} else {
+				os.Unsetenv("DRONE_STAGE_TYPE")
+			}
+
+			got := normalizeDockerPath(tt.input)
+			if got != tt.expected {
+				t.Errorf("normalizeDockerPath(%q) = %q, want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
 }

--- a/cache/restorer.go
+++ b/cache/restorer.go
@@ -243,7 +243,7 @@ func (r restorer) Restore(dsts []string, cacheFileName string) error {
 		if originalPath, exists := sourcePaths[dst]; exists {
 			src = originalPath
 		} else {
-			src = filepath.Join(namespace, key, dst)
+			src = filepath.Join(namespace, key, normalizeDockerPath(dst))
 		}
 
 		level.Info(r.logger).Log("msg", "restoring directory", "local", dst, "remote", src)


### PR DESCRIPTION
# fix: [CI-20023] Fix cache key for Docker infrastructure paths

## Summary

In Docker infrastructure, cache source paths are volume-mounted under a UUID-based directory:

```
/tmp/harness/d-q4SY6lQoiHPwnP9R6aog/.m2/repository
```

This UUID changes on every pipeline run, so the remote storage key was always different — causing a **100% cache miss rate** in Docker infra regardless of whether the cache was previously saved.

## Root Cause

The remote storage key was built directly from the source path:

```go
dst := filepath.Join(namespace, key, src)
// → intel/<account>/<key>/tmp/harness/d-q4SY6lQoiHPwnP9R6aog/.m2/repository
```

Since the UUID segment (`d-q4SY6lQoiHPwnP9R6aog`) is different every run, no cache hit was ever possible.

## Fix

Introduced `normalizeDockerPath()` in `cache/rebuilder.go`. When `DRONE_STAGE_TYPE=DOCKER`, paths matching the harness volume mount pattern are normalized to a stable key:

```
/tmp/harness/<uuid>/.m2/repository  →  docker/.m2/repository
C:/tmp/harness/<uuid>/.m2/repository  →  docker/.m2/repository  (Windows)
```

Applied symmetrically on both **save** (`rebuilder.go`) and **restore** (`restorer.go`) so keys always match.

## Changes

| File | Description |
|------|-------------|
| `cache/rebuilder.go` | Added `normalizeDockerPath()`, applied to remote key on save |
| `cache/restorer.go` | Applied `normalizeDockerPath()` to remote key on restore |
| `cache/rebuilder_test.go` | 8 unit tests covering all branches |

## Backward Compatibility

The normalization is **entirely gated** behind `DRONE_STAGE_TYPE=DOCKER`. All other runner types (K8s, VM, bare-metal) are completely unaffected.

### Local Testing
<img width="1728" height="1117" alt="Screenshot 2026-04-07 at 1 17 17 AM" src="https://github.com/user-attachments/assets/d3072887-7c51-435b-a79c-ece18a57c8db" />


### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.


[CI-20023]: https://harness.atlassian.net/browse/CI-20023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ