### PR TITLE
feat(CI-22209): honour NUGET_PACKAGES env var in dotnet auto-detect

### DIFF
--- a/internal/plugin/autodetect/auto_detect_util_test.go
+++ b/internal/plugin/autodetect/auto_detect_util_test.go
@@ -117,6 +117,54 @@ func TestDetectDirectoriesToCacheGradleKts(t *testing.T) {
 	test.Equals(t, hashes, "baab6c16d9143523b7865d46896e4596")
 }
 
+func TestDetectDirectoriesToCacheDotnet(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Unsetenv("NUGET_PACKAGES")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	csprojFile := "test.csproj"
+	f, err := os.Create(csprojFile)
+	test.Ok(t, err)
+	defer f.Close()
+	_, err = f.WriteString(testFileContent)
+	test.Ok(t, err)
+
+	directoriesToCache, buildToolsDetected, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+	test.Ok(t, os.RemoveAll(csprojFile))
+	test.Ok(t, os.RemoveAll("nuget.config"))
+
+	path, _ := filepath.Abs(".nuget/packages")
+	expectedCacheDir := []string{path}
+	expectedDetectedTool := []string{"dotnet"}
+
+	test.Equals(t, directoriesToCache, expectedCacheDir)
+	test.Equals(t, buildToolsDetected, expectedDetectedTool)
+}
+
+func TestDetectDirectoriesToCacheDotnetWithEnvVar(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Setenv("NUGET_PACKAGES", "/custom/dotnet/cache")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	csprojFile := "test.csproj"
+	f, err := os.Create(csprojFile)
+	test.Ok(t, err)
+	defer f.Close()
+	_, err = f.WriteString(testFileContent)
+	test.Ok(t, err)
+
+	directoriesToCache, buildToolsDetected, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+	test.Ok(t, os.RemoveAll(csprojFile))
+
+	expectedCacheDir := []string{"/custom/dotnet/cache"}
+	expectedDetectedTool := []string{"dotnet"}
+
+	test.Equals(t, directoriesToCache, expectedCacheDir)
+	test.Equals(t, buildToolsDetected, expectedDetectedTool)
+}
+
 func TestDetectDirectoriesToCacheCombined(t *testing.T) {
 	f, err := os.Create(bazelBuildFile)
 	test.Ok(t, err)

--- a/internal/plugin/autodetect/prepare_dotnet.go
+++ b/internal/plugin/autodetect/prepare_dotnet.go
@@ -30,6 +30,17 @@ func newDotnetPreparer() *dotnetPreparer {
 }
 
 func (*dotnetPreparer) PrepareRepo(dir string) (string, error) {
+	// NUGET_PACKAGES env var takes precedence over nuget.config's globalPackagesFolder.
+	// When set (e.g., by a Docker image or CI stage variable), NuGet ignores
+	// globalPackagesFolder entirely, so we cache the env var path instead.
+	if nugetPkgs := os.Getenv("NUGET_PACKAGES"); nugetPkgs != "" {
+		absPath, err := filepath.Abs(nugetPkgs)
+		if err != nil {
+			return "", fmt.Errorf("failed to resolve NUGET_PACKAGES path %q: %w", nugetPkgs, err)
+		}
+		return filepath.Clean(absPath), nil
+	}
+
 	pathToCache := filepath.Join(dir, ".nuget", "packages")
 	configPath := filepath.Join(dir, "nuget.config")
 	updateConfig := false

--- a/internal/plugin/autodetect/prepare_dotnet_test.go
+++ b/internal/plugin/autodetect/prepare_dotnet_test.go
@@ -1,0 +1,192 @@
+package autodetect
+
+import (
+	"encoding/xml"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/meltwater/drone-cache/test"
+)
+
+func TestDotnetPreparerRespectsNugetPackagesEnvVar(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Setenv("NUGET_PACKAGES", "/custom/cache/path")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	dir, err := os.MkdirTemp("", "dotnet-env-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	preparer := newDotnetPreparer()
+	pathToCache, err := preparer.PrepareRepo(dir)
+	test.Ok(t, err)
+
+	test.Equals(t, "/custom/cache/path", pathToCache)
+
+	// nuget.config should NOT have been created
+	_, err = os.Stat(filepath.Join(dir, "nuget.config"))
+	test.Assert(t, os.IsNotExist(err), "nuget.config should not be created when NUGET_PACKAGES is set")
+}
+
+func TestDotnetPreparerNugetPackagesRelativePath(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Setenv("NUGET_PACKAGES", "relative/cache/path")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	dir, err := os.MkdirTemp("", "dotnet-rel-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	preparer := newDotnetPreparer()
+	pathToCache, err := preparer.PrepareRepo(dir)
+	test.Ok(t, err)
+
+	// Should resolve to absolute path
+	test.Assert(t, filepath.IsAbs(pathToCache),
+		"returned path should be absolute, got: %s", pathToCache)
+
+	expectedAbs, _ := filepath.Abs("relative/cache/path")
+	test.Equals(t, expectedAbs, pathToCache)
+}
+
+func TestDotnetPreparerFallsBackToNugetConfig(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Unsetenv("NUGET_PACKAGES")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	dir, err := os.MkdirTemp("", "dotnet-fallback-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	preparer := newDotnetPreparer()
+	pathToCache, err := preparer.PrepareRepo(dir)
+	test.Ok(t, err)
+
+	expectedPath := filepath.Join(dir, ".nuget", "packages")
+	test.Equals(t, expectedPath, pathToCache)
+
+	// nuget.config should have been created
+	configPath := filepath.Join(dir, "nuget.config")
+	_, err = os.Stat(configPath)
+	test.Assert(t, !os.IsNotExist(err), "nuget.config should be created when NUGET_PACKAGES is not set")
+
+	// Verify the config contains globalPackagesFolder
+	data, err := os.ReadFile(configPath)
+	test.Ok(t, err)
+
+	var config Configuration
+	test.Ok(t, xml.Unmarshal(data, &config))
+	test.Assert(t, config.Config != nil, "config section should exist")
+
+	found := false
+	for _, add := range config.Config.Add {
+		if add.Key == "globalPackagesFolder" {
+			test.Equals(t, expectedPath, add.Value)
+			found = true
+		}
+	}
+	test.Assert(t, found, "globalPackagesFolder should be set in nuget.config")
+}
+
+func TestDotnetPreparerExistingNugetConfig(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Unsetenv("NUGET_PACKAGES")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	dir, err := os.MkdirTemp("", "dotnet-existing-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	expectedPath := filepath.Join(dir, ".nuget", "packages")
+
+	// Create existing nuget.config with the correct globalPackagesFolder
+	existingConfig := Configuration{
+		Config: &Config{
+			Add: []Add{
+				{Key: "globalPackagesFolder", Value: expectedPath},
+			},
+		},
+	}
+	configData, err := xml.MarshalIndent(existingConfig, "", "  ")
+	test.Ok(t, err)
+	test.Ok(t, os.WriteFile(filepath.Join(dir, "nuget.config"), configData, 0644))
+
+	preparer := newDotnetPreparer()
+	pathToCache, err := preparer.PrepareRepo(dir)
+	test.Ok(t, err)
+
+	test.Equals(t, expectedPath, pathToCache)
+
+	// Verify no duplicate entries were added
+	data, err := os.ReadFile(filepath.Join(dir, "nuget.config"))
+	test.Ok(t, err)
+
+	var config Configuration
+	test.Ok(t, xml.Unmarshal(data, &config))
+
+	count := 0
+	for _, add := range config.Config.Add {
+		if add.Key == "globalPackagesFolder" {
+			count++
+		}
+	}
+	test.Equals(t, 1, count)
+}
+
+func TestDotnetPreparerEnvVarTakesPrecedenceOverConfig(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Setenv("NUGET_PACKAGES", "/env/path")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	dir, err := os.MkdirTemp("", "dotnet-precedence-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	// Create existing nuget.config with a different path
+	existingConfig := Configuration{
+		Config: &Config{
+			Add: []Add{
+				{Key: "globalPackagesFolder", Value: "/some/other/path"},
+			},
+		},
+	}
+	configData, err := xml.MarshalIndent(existingConfig, "", "  ")
+	test.Ok(t, err)
+	configPath := filepath.Join(dir, "nuget.config")
+	test.Ok(t, os.WriteFile(configPath, configData, 0644))
+
+	// Save original config content for comparison
+	originalContent, err := os.ReadFile(configPath)
+	test.Ok(t, err)
+
+	preparer := newDotnetPreparer()
+	pathToCache, err := preparer.PrepareRepo(dir)
+	test.Ok(t, err)
+
+	// Env var should win
+	test.Equals(t, "/env/path", pathToCache)
+
+	// nuget.config should not have been modified
+	afterContent, err := os.ReadFile(configPath)
+	test.Ok(t, err)
+	test.Equals(t, string(originalContent), string(afterContent))
+}
+
+func TestDotnetPreparerEmptyEnvVarFallsBack(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Setenv("NUGET_PACKAGES", "")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	dir, err := os.MkdirTemp("", "dotnet-empty-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	preparer := newDotnetPreparer()
+	pathToCache, err := preparer.PrepareRepo(dir)
+	test.Ok(t, err)
+
+	// Should fall back to nuget.config behavior
+	expectedPath := filepath.Join(dir, ".nuget", "packages")
+	test.Equals(t, expectedPath, pathToCache)
+}


### PR DESCRIPTION
## Summary

When `NUGET_PACKAGES` is set as a stage variable or by a Docker image, NuGet ignores `nuget.config`'s `globalPackagesFolder` entirely. The cache plugin was unaware of this, causing it to cache `.nuget/packages` (from config) while `dotnet restore` was actually writing to the env var path — resulting in a cache miss every run.

This fix makes the plugin check `NUGET_PACKAGES` first and use that path directly as the cache directory, skipping `nuget.config` modification when it would be silently overridden anyway.

## Changes

- **`internal/plugin/autodetect/prepare_dotnet.go`** — At the top of `PrepareRepo()`, read `NUGET_PACKAGES`; if set, resolve to absolute path and return immediately. Falls back to existing `nuget.config` logic when not set.
- **`internal/plugin/autodetect/prepare_dotnet_test.go`** *(new)* — 6 unit tests: env var respected, relative path resolution, fallback to nuget.config, existing config no duplicates, env var precedence over config, empty env var fallback.
- **`internal/plugin/autodetect/auto_detect_util_test.go`** — 2 integration tests for end-to-end dotnet detection with and without `NUGET_PACKAGES`.

## Customer Context

Customers manually configured caching by setting `NUGET_PACKAGES=/dotnetcache` as a stage variable and specifying that path as both the shared path and cache intel folder. Observed **~50% build time reduction** (4 min → 1:30 min). This fix makes that configuration automatic — users only need to set the `NUGET_PACKAGES` stage variable.

## How to Test

1. Create a pipeline with a `*.csproj` at repo root.
2. Set stage variable `NUGET_PACKAGES=/dotnetcache`.
3. Add Restore Cache → Build (`dotnet restore`) → Rebuild Cache steps.
4. Run twice. On the second run, confirm:
   - Cache plugin log shows `PackagesPath=/dotnetcache`
   - No `GET` requests to nuget.org for `.nupkg` files in `dotnet restore` output
   - `dotnet restore` completes in under 2s (vs 10–30s cold)

## Testing

Full run: https://app.harness.io/ng/account/9UuUfLwaQ-6ZowvbG7qtLQ/module/ci/orgs/default/projects/Intel_Features/pipelines/dotnet/deployments/1A-oS7kEQaSLhv1Az5J8Xg/pipeline?storeType=INLINE
Optimized Run: https://app.harness.io/ng/account/9UuUfLwaQ-6ZowvbG7qtLQ/module/ci/orgs/default/projects/Intel_Features/pipelines/dotnet/deployments/npPZEyxqT2yWPso94qe6VQ/pipeline?storeType=INLINE



### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
