### PR TITLE
feat: [CI-21196]: Added rootless windows images

### DIFF
--- a/docker/Dockerfile.rootless.linux.amd64
+++ b/docker/Dockerfile.rootless.linux.amd64
@@ -1,0 +1,14 @@
+FROM golang:1.25.7-alpine3.23 AS builder
+RUN apk add --update --no-cache ca-certificates tzdata && update-ca-certificates
+RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
+
+FROM scratch as runner
+
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+ADD release/linux/amd64/drone-cache /bin/
+USER nonroot:nonroot
+ENTRYPOINT ["/bin/drone-cache"]

--- a/docker/Dockerfile.rootless.linux.arm64
+++ b/docker/Dockerfile.rootless.linux.arm64
@@ -1,0 +1,14 @@
+FROM golang:1.25.7-alpine3.23 AS builder
+RUN apk add --update --no-cache ca-certificates tzdata && update-ca-certificates
+RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
+
+FROM scratch as runner
+
+COPY --from=builder /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /etc/passwd /etc/passwd
+COPY --from=builder /etc/group /etc/group
+
+ADD release/linux/arm64/drone-cache /bin/
+USER nonroot:nonroot
+ENTRYPOINT ["/bin/drone-cache"]

--- a/docker/Dockerfile.windows.1809.rootless
+++ b/docker/Dockerfile.windows.1809.rootless
@@ -1,0 +1,13 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2019 as core
+
+
+FROM mcr.microsoft.com/windows/nanoserver:1809
+USER ContainerUser
+
+ENV GODEBUG=netdns=go
+COPY --from=core /windows/system32/netapi32.dll /windows/system32/netapi32.dll
+
+ADD release/windows/amd64/drone-cache.exe C:/drone-cache.exe
+ENTRYPOINT [ "C:\\drone-cache.exe" ]

--- a/docker/Dockerfile.windows.ltsc2022.rootless
+++ b/docker/Dockerfile.windows.ltsc2022.rootless
@@ -1,0 +1,8 @@
+# escape=`
+FROM plugins/base:windows-ltsc2022-amd64@sha256:0f90d5bceb432f1ee6f93cf44eed6a38c322834edd55df8a6648c9e6f15131f4
+USER ContainerUser
+
+ENV GODEBUG=netdns=go
+
+ADD release/windows/amd64/drone-cache.exe C:/drone-cache.exe
+ENTRYPOINT [ "C:\\drone-cache.exe" ]

--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -1,0 +1,20 @@
+image: plugins/cache:{{#if build.tag}}{{trimPrefix "v" build.tag}}-rootless{{else}}rootless{{/if}}
+{{#if build.tags}}
+tags:
+{{#each build.tags}}
+  - {{this}}-rootless
+{{/each}}
+{{/if}}
+manifests:
+  -
+    image: plugins/cache:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-1809-amd64-rootless
+    platform:
+      architecture: amd64
+      os: windows
+      version: 1809
+  -
+    image: plugins/cache:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2022-amd64-rootless
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2022

--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -7,6 +7,17 @@ tags:
 {{/if}}
 manifests:
   -
+    image: plugins/cache:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-amd64-rootless
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: plugins/cache:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}linux-arm64-rootless
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8
+  -
     image: plugins/cache:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-1809-amd64-rootless
     platform:
       architecture: amd64


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Thank you for your pull request. Please provide a description above and review
the requirements below.

**BUG FIXES AND NEW FEATURES SHOULD INCLUDE TESTS.**

Contributors guide: ./CONTRIBUTING.md
Code of conduct: ./CODE_OF_CONDUCT.md
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.
## Proposed Changes
### Description
Adds rootless Windows container image variants for the `plugins/cache` plugin, following the same `-rootless` convention already used for the Linux images. This allows the plugin to run as a non-privileged user (`ContainerUser`) on Windows hosts, matching hardened / non-root execution policies.
**What's added:**
| File | Purpose |
| --- | --- |
| `docker/Dockerfile.windows.1809.rootless` | Windows 1809 (nanoserver) image running as `ContainerUser` instead of `ContainerAdministrator`. Keeps the existing `netapi32.dll` copy from the `ltsc2019` servercore stage so Go DNS resolution (`GODEBUG=netdns=go`) continues to work. |
| `docker/Dockerfile.windows.ltsc2022.rootless` | Windows `ltsc2022` image built on `plugins/base:windows-ltsc2022-amd64` and running as `ContainerUser`. |
| `docker/manifest.rootless.tmpl` | New multi-arch manifest template that publishes `plugins/cache:<tag>-rootless` (and `rootless` for untagged builds), aggregating the `windows-1809-amd64-rootless` and `windows-ltsc2022-amd64-rootless` images. |

**What's NOT changed:**
- No behavioural change to existing root images (`Dockerfile.windows.1809`, `Dockerfile.windows.ltsc2022`, `manifest.tmpl`).
- No Go / plugin source code changes — this is a packaging-only change.
- CI pipeline updates to build & publish the new images will be handled separately (drone/harness pipeline config).
### Jira
[CI-21196](https://harness.atlassian.net/browse/CI-21196)

### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.


[CI-21196]: https://harness.atlassian.net/browse/CI-21196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ