### PR TITLE
feat: [CI-22212]: PRESERVE_METADATA for harness backend

### DIFF
--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -195,7 +195,7 @@ func (p *Plugin) Exec() error { // nolint:funlen
 		archive.FromFormat(p.logger, localRoot, cfg.ArchiveFormat,
 			archive.WithSkipSymlinks(cfg.SkipSymlinks),
 			archive.WithCompressionLevel(cfg.CompressionLevel),
-			archive.WithPreserveMetadata(cfg.PreserveMetadata && (cfg.Backend == backend.S3 || cfg.Backend == backend.GCS || cfg.Backend == backend.Azure)),
+			archive.WithPreserveMetadata(cfg.PreserveMetadata), // archive-level feature; backend-agnostic
 		),
 		generator,
 		cfg.Backend,


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Thank you for your pull request. Please provide a description above and review
the requirements below.

**BUG FIXES AND NEW FEATURES SHOULD INCLUDE TESTS.**

Contributors guide: ./CONTRIBUTING.md
Code of conduct: ./CODE_OF_CONDUCT.md
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.

## Proposed Changes
Enable PRESERVE_METADATA for harness backend

## What
Remove the backend restriction on `WithPreserveMetadata` so that `PLUGIN_PRESERVE_METADATA=true` works with the Harness Cloud backend in addition to S3, GCS, and Azure.

## Why
`PRESERVE_METADATA` is an archive-layer feature (uid/gid/atime/ctime written into the tar header). It has no dependency on the storage backend — the backend only stores and retrieves bytes. The restriction was incorrectly gating a backend-agnostic feature.

### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [ ] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
