### PR TITLE
fix: [CI-22506]: Upgrade Go to 1.25.9 to remediate stdlib CVEs

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,7 +32,7 @@ steps:
   - name: build
     # there is an issue in golang 1.17.7-alpine3.15 -- with make files so using 1.17.3 here
     # https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
-    image: golang:1.25.7-alpine3.23
+    image: golang:1.25.9-alpine3.23
     commands:
       - apk add --update make git
       - make drone-cache
@@ -41,7 +41,7 @@ steps:
 
     
   - name: test
-    image: golang:1.25.7-alpine3.23
+    image: golang:1.25.9-alpine3.23
     commands:
       - go test -mod=vendor -short -cover -tags=integration ./...
     environment:
@@ -248,7 +248,7 @@ platform:
 steps:
   - name: build-push
     pull: always
-    image: golang:1.25.7
+    image: golang:1.25.9
     commands:
       - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/amd64/drone-cache'
     environment:
@@ -256,7 +256,7 @@ steps:
       GO111MODULE: on
   - name: build-tag
     pull: always
-    image: golang:1.25.7
+    image: golang:1.25.9
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/amd64/drone-cache'
     environment:
@@ -303,7 +303,7 @@ platform:
 steps:
   - name: build-push
     pull: always
-    image: golang:1.25.7
+    image: golang:1.25.9
     commands:
       - 'go build -v -ldflags "-X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm64/drone-cache'
     environment:
@@ -311,7 +311,7 @@ steps:
       GO111MODULE: on
   - name: build-tag
     pull: always
-    image: golang:1.25.7
+    image: golang:1.25.9
     commands:
       - 'go build -v -ldflags "-X main.version=${DRONE_TAG##v} -X main.build=${DRONE_BUILD_NUMBER}" -a -o release/linux/arm64/drone-cache'
     environment:
@@ -357,7 +357,7 @@ platform:
 
 steps:
   - name: build
-    image: golang:1.25.7
+    image: golang:1.25.9
     commands:
       - echo $env:DRONE_SEMVER_SHORT
       - go build -o release/windows/amd64/drone-cache.exe
@@ -404,7 +404,7 @@ platform:
 
 steps:
   - name: build
-    image: golang:1.25.7
+    image: golang:1.25.9
     commands:
       - echo $env:DRONE_SEMVER_SHORT
       - go build -o release/windows/amd64/drone-cache.exe
@@ -480,7 +480,7 @@ pool:
 
 steps:
   - name: build
-    image: golang:1.25.7
+    image: golang:1.25.9
     commands:
       - GOOS=linux   GOARCH=amd64   go build -ldflags "-s -w -X main.version=${DRONE_TAG##v}" -o release/plugin-linux-amd64
       - GOOS=linux   GOARCH=arm64   go build -ldflags "-s -w -X main.version=${DRONE_TAG##v}" -o release/plugin-linux-arm64

--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine3.23 AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 RUN apk add --update --no-cache ca-certificates tzdata busybox-static && update-ca-certificates
 
 FROM scratch as runner

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine3.23 AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 RUN apk add --update --no-cache ca-certificates tzdata busybox-static && update-ca-certificates
 
 FROM scratch as runner

--- a/docker/Dockerfile.rootless.linux.amd64
+++ b/docker/Dockerfile.rootless.linux.amd64
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine3.23 AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 RUN apk add --update --no-cache ca-certificates tzdata && update-ca-certificates
 RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
 

--- a/docker/Dockerfile.rootless.linux.arm64
+++ b/docker/Dockerfile.rootless.linux.arm64
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-alpine3.23 AS builder
+FROM golang:1.25.9-alpine3.23 AS builder
 RUN apk add --update --no-cache ca-certificates tzdata && update-ca-certificates
 RUN addgroup -g 65532 -S nonroot && adduser -u 65532 -S nonroot -G nonroot
 

--- a/go.mod
+++ b/go.mod
@@ -81,4 +81,4 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 )
 
-go 1.25.7
+go 1.25.9


### PR DESCRIPTION
<!--
**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Thank you for your pull request. Please provide a description above and review
the requirements below.

**BUG FIXES AND NEW FEATURES SHOULD INCLUDE TESTS.**

Contributors guide: ./CONTRIBUTING.md
Code of conduct: ./CODE_OF_CONDUCT.md
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our [code of conduct](CODE_OF_CONDUCT.md), and the process for submitting pull requests to us.

Fixes #

## Proposed Changes

 Bumps Go toolchain from 1.25.7 → 1.25.9 to remediate 4 High-severity stdlib CVEs flagged in harnesssecure/cache:1.10.4 (Jira: CI-22506).                                                                                                          
                                                                                                                                                                                                                                                    
  - CVE-2026-25679 (net/url) — fixed in 1.25.8                                                                                                                                                                                                      
  - CVE-2026-32280, CVE-2026-32281 (crypto/x509) — fixed in 1.25.9                                                                                                                                                                                  
  - CVE-2026-32283 (crypto/tls) — fixed in 1.25.9                                                                                                                                                                                                   
                                                                                                                                                                                                                                                    
  Updates `go.mod` and all four Linux Dockerfile builder images (standard + rootless, amd64 + arm64). 
### Description

<!-- Please explain the changes you made here. -->

### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [x] Add tests to cover changes.
- [x] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
