### PR TITLE
fix: [CI-22408]: allow PLUGIN_ACL=none to disable x-amz-acl on S3 cache uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- backend/s3: Allow `PLUGIN_ACL=none` (or `disabled`, `off`) to disable the `x-amz-acl` header so caches can be uploaded to S3 buckets with Object Ownership = `BucketOwnerEnforced` (ACLs disabled). Fixes [CI-22408](https://harness.atlassian.net/browse/CI-22408).
 - [#72](https://github.com/drone-plugins/drone-meltwater-cache/pull/72) Fixed inputs for Azure
 - [#133](https://github.com/meltwater/drone-cache/pull/133) bacnkend/s3: Fixed Anonymous Credentials Error on public buckets. 
   - Fixes [#132](https://github.com/meltwater/drone-cache/issues/132)

--- a/DOCS.md
+++ b/DOCS.md
@@ -371,7 +371,7 @@ path-style
 : use path style for bucket paths. (true for `minio`, false for `aws`)
 
 acl
-: upload files with acl (`private`, `public-read`, ...) (default: `private`)
+: upload files with acl (`private`, `public-read`, ...) (default: `private`). Set to `none`, `disabled`, or `off` to omit the `x-amz-acl` header entirely — required for S3 buckets with Object Ownership set to `BucketOwnerEnforced` (ACLs disabled), which reject any canned ACL other than `bucket-owner-full-control`.
 
 encryption
 : server-side encryption algorithm, defaults to `none`. (`AES256`, `aws:kms`)

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ GLOBAL OPTIONS:
    --secret-key value                    AWS secret key [$PLUGIN_SECRET_KEY, $AWS_SECRET_ACCESS_KEY, $CACHE_AWS_SECRET_ACCESS_KEY]
    --region value                        AWS bucket region. (us-east-1, eu-west-1, ...) [$PLUGIN_REGION, $S3_REGION]
    --path-style                          AWS path style to use for bucket paths. (true for minio, false for aws) (default: false) [$PLUGIN_PATH_STYLE, $AWS_PLUGIN_PATH_STYLE]
-   --acl value                           upload files with acl (private, public-read, ...) [$PLUGIN_ACL, $AWS_ACL]
+   --acl value                           upload files with acl (private, public-read, ...; use none, disabled, or off to disable for ACL-disabled buckets) [$PLUGIN_ACL, $AWS_ACL]
    --encryption value                    server-side encryption algorithm, defaults to none. (AES256, aws:kms) [$PLUGIN_ENCRYPTION, $AWS_ENCRYPTION]
    --sts-endpoint value                  Custom STS endpoint for IAM role assumption [$PLUGIN_STS_ENDPOINT, $AWS_STS_ENDPOINT]
    --role-arn value                      AWS IAM role ARN to assume [$PLUGIN_ASSUME_ROLE_ARN, $AWS_ASSUME_ROLE_ARN]

--- a/main.go
+++ b/main.go
@@ -416,7 +416,7 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:    "acl",
-			Usage:   "upload files with acl (private, public-read, ...)",
+			Usage:   "upload files with acl (private, public-read, ...; use none, disabled, or off to disable for ACL-disabled buckets)",
 			EnvVars: []string{"PLUGIN_ACL", "AWS_ACL"},
 		},
 		&cli.StringFlag{

--- a/storage/backend/s3/s3.go
+++ b/storage/backend/s3/s3.go
@@ -141,7 +141,11 @@ func New(l log.Logger, c Config, debug bool) (*Backend, error) {
 	}
 
 	if c.ACL != "" {
-		backend.acl = c.ACL
+		if isACLDisabled(c.ACL) {
+			logrus.WithField("acl", c.ACL).Info("PLUGIN_ACL set to disable sentinel; x-amz-acl header will not be sent")
+		} else {
+			backend.acl = c.ACL
+		}
 	}
 
 	return backend, nil
@@ -152,6 +156,19 @@ func normalizeEndpoint(endpoint string) string {
 		return endpoint
 	}
 	return "https://" + endpoint
+}
+
+// isACLDisabled returns true when the ACL value is a sentinel that means
+// "do not send the x-amz-acl header". Used so customers can opt out of ACL
+// on buckets with Object Ownership = BucketOwnerEnforced (ACLs disabled),
+// where any canned ACL other than bucket-owner-full-control is rejected with
+// AccessControlListNotSupported.
+func isACLDisabled(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "none", "disabled", "off":
+		return true
+	}
+	return false
 }
 
 // Get writes downloaded content to the given writer.

--- a/storage/backend/s3/s3_unit_test.go
+++ b/storage/backend/s3/s3_unit_test.go
@@ -160,6 +160,38 @@ func TestDetectDirectoryBucket_SuffixButNotDirectoryBucket(t *testing.T) {
 	test.Equals(t, false, result, "bucket with --x-s3 suffix but empty BucketLocationType should return false")
 }
 
+func TestIsACLDisabled(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    string
+		expected bool
+	}{
+		{name: "empty string is not a sentinel", input: "", expected: false},
+		{name: "lowercase none", input: "none", expected: true},
+		{name: "uppercase NONE", input: "NONE", expected: true},
+		{name: "mixed case None", input: "None", expected: true},
+		{name: "none with surrounding whitespace", input: " none ", expected: true},
+		{name: "lowercase disabled", input: "disabled", expected: true},
+		{name: "uppercase DISABLED", input: "DISABLED", expected: true},
+		{name: "lowercase off", input: "off", expected: true},
+		{name: "uppercase OFF", input: "OFF", expected: true},
+		{name: "private is a real ACL", input: "private", expected: false},
+		{name: "public-read is a real ACL", input: "public-read", expected: false},
+		{name: "bucket-owner-full-control is a real ACL", input: "bucket-owner-full-control", expected: false},
+		{name: "arbitrary value is not a sentinel", input: "no", expected: false},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			test.Equals(t, tc.expected, isACLDisabled(tc.input), tc.name)
+		})
+	}
+}
+
 func TestPut_ACLHandling_RegularBucket(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes [CI-22408](https://harness.atlassian.net/browse/CI-22408)

## Proposed Changes

- `storage/backend/s3/s3.go`: add `isACLDisabled` helper. In `New`, when `PLUGIN_ACL` matches the sentinel values `none`, `disabled`, or `off` (case-insensitive, trimmed), leave `backend.acl` empty so the `Put` path does not attach `x-amz-acl` to the S3 request.
- `main.go`, `DOCS.md`, `README.md`: document the new sentinel values on the `--acl` / `PLUGIN_ACL` flag.
- `storage/backend/s3/s3_unit_test.go`: add `TestIsACLDisabled` table test covering empty, sentinel, and real canned-ACL values.
- `CHANGELOG.md`: add Unreleased entry.

### Description

When a customer's S3 bucket has Object Ownership set to `BucketOwnerEnforced` (the AWS default for new buckets since April 2023), AWS rejects any canned ACL header other than `bucket-owner-full-control` with HTTP 400 `AccessControlListNotSupported: The bucket does not allow ACLs`. The Harness Cache Intelligence cache step hit this on CreateMultipartUpload because:

1. The plugin sends `x-amz-acl` whenever `PLUGIN_ACL` is non-empty.
2. The upstream Harness CI manager injects `PLUGIN_ACL=private` by default (originally added in harness-core PR #56087 to address CI-10547 for OVH), so simply removing `acl` from the pipeline YAML does not stop the header from being sent — the upstream default still wins unless the step explicitly overrides it.

This change gives customers an in-pipeline opt-out: setting `PLUGIN_ACL=none` (or `disabled` / `off`) at the step level overrides the upstream `private` injection and tells the plugin not to send the header at all, which is what `BucketOwnerEnforced` requires.

Existing canned-ACL values (`private`, `public-read`, `bucket-owner-full-control`, ...) continue to be forwarded to S3 unchanged.

Note: customers can also unblock themselves today, before this PR ships, by setting `PLUGIN_ACL=bucket-owner-full-control` at the step level — AWS documents that value as accepted on `BucketOwnerEnforced` buckets. The sentinel-based opt-out introduced here is the cleaner long-term option.

Existing pattern in this same file (S3 Express directory buckets — CI-13695, CI-21463, CI-22058) already skips the ACL header conditionally; this change extends that pattern with a customer-controllable knob for the regular-bucket case.

I considered two alternative approaches and rejected both:
- Auto-retry without ACL on `AccessControlListNotSupported`: the upload uses non-seekable pipe readers, so the body cannot be replayed safely.
- Probe `GetBucketOwnershipControls` at startup: requires an additional IAM permission that many cross-account roles don't grant.

### Checklist

- [x] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [x] Add tests to cover changes.
- [x] Ensure your code follows the code style of this project.
- [x] Code compiles correctly.
- [x] All new and existing tests passed.
- [x] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [x] Improve and update the [README](README.md) (if necessary).
- [x] Ensure [documentation](./DOCS.md) is up-to-date.

[CI-22408]: https://harness.atlassian.net/browse/CI-22408?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ