### PR TITLE
feat[CI-16621]: support per-project .NET caching for multi-project re…

### DIFF
--- a/internal/plugin/autodetect/auto_detect_util.go
+++ b/internal/plugin/autodetect/auto_detect_util.go
@@ -6,12 +6,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 type buildToolInfo struct {
-	globToDetect string
-	tool         string
-	preparer     RepoPreparer
+	globToDetect  string
+	tool          string
+	preparer      RepoPreparer
+	usePerProject bool
 }
 
 // containsTool checks if a tool is already in the slice
@@ -70,19 +72,22 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 			preparer:     newGoPreparer(),
 		},
 		{
-			globToDetect: "*.csproj",
-			tool:         "dotnet",
-			preparer:     newDotnetPreparer(),
+			globToDetect:  "*.csproj",
+			tool:          "dotnet",
+			preparer:      newDotnetPreparer(),
+			usePerProject: true,
 		},
 		{
-			globToDetect: "*.vbproj",
-			tool:         "dotnet",
-			preparer:     newDotnetPreparer(),
+			globToDetect:  "*.vbproj",
+			tool:          "dotnet",
+			preparer:      newDotnetPreparer(),
+			usePerProject: true,
 		},
 		{
-			globToDetect: "*.fsproj",
-			tool:         "dotnet",
-			preparer:     newDotnetPreparer(),
+			globToDetect:  "*.fsproj",
+			tool:          "dotnet",
+			preparer:      newDotnetPreparer(),
+			usePerProject: true,
 		},
 	}
 
@@ -100,28 +105,49 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 			continue
 		}
 
-		hash, dir, err := hashIfFileExist(supportedTool.globToDetect)
-		if err != nil {
-			return nil, nil, "", err
-		}
-		if hash == "" {
-			hash, dir, err = hashIfFileExist(filepath.Join("**", supportedTool.globToDetect))
+		if supportedTool.usePerProject {
+			hash, dirs, err := hashAllFilesPerProjectIfExist(supportedTool.globToDetect)
 			if err != nil {
 				return nil, nil, "", err
 			}
-		}
-		if err != nil {
-			return nil, nil, "", err
-		}
-		if hash != "" && !skipPrepare {
-			dirToCache, err := supportedTool.preparer.PrepareRepo(dir)
+			if hash == "" {
+				hash, dirs, err = hashAllFilesPerProjectIfExist(filepath.Join("**", supportedTool.globToDetect))
+				if err != nil {
+					return nil, nil, "", err
+				}
+			}
+			if hash != "" && !skipPrepare {
+				for _, dir := range dirs {
+					dirToCache, err := supportedTool.preparer.PrepareRepo(dir)
+					if err != nil {
+						return nil, nil, "", err
+					}
+					directoriesToCache = appendIfMissing(directoriesToCache, dirToCache)
+				}
+				buildToolsDetected = appendIfMissing(buildToolsDetected, supportedTool.tool)
+				hashes += hash
+			}
+		} else {
+			hash, dir, err := hashIfFileExist(supportedTool.globToDetect)
 			if err != nil {
 				return nil, nil, "", err
 			}
+			if hash == "" {
+				hash, dir, err = hashIfFileExist(filepath.Join("**", supportedTool.globToDetect))
+				if err != nil {
+					return nil, nil, "", err
+				}
+			}
+			if hash != "" && !skipPrepare {
+				dirToCache, err := supportedTool.preparer.PrepareRepo(dir)
+				if err != nil {
+					return nil, nil, "", err
+				}
 
-			directoriesToCache = appendIfMissing(directoriesToCache, dirToCache)
-			buildToolsDetected = appendIfMissing(buildToolsDetected, supportedTool.tool)
-			hashes += hash
+				directoriesToCache = appendIfMissing(directoriesToCache, dirToCache)
+				buildToolsDetected = appendIfMissing(buildToolsDetected, supportedTool.tool)
+				hashes += hash
+			}
 		}
 	}
 
@@ -145,6 +171,16 @@ func hashIfFileExist(glob string) (string, string, error) {
 	}
 
 	return calculateMd5FromFiles(matches)
+}
+
+func hashAllFilesPerProjectIfExist(glob string) (string, []string, error) {
+	matches, _ := filepath.Glob(glob)
+
+	if len(matches) == 0 {
+		return "", nil, nil
+	}
+
+	return calculateMd5FromAllFilesPerProject(matches)
 }
 
 func calculateMd5FromFiles(fileList []string) (string, string, error) {
@@ -171,6 +207,47 @@ func calculateMd5FromFiles(fileList []string) (string, string, error) {
 	}
 
 	return hex.EncodeToString(hash.Sum(nil)), dir, nil
+}
+
+// calculateMd5FromAllFilesPerProject hashes all files in the list and returns
+// a deduplicated slice of their absolute parent directories. Used for .NET
+// projects so each project directory gets its own nuget.config and cache entry.
+//
+// Files are sorted before hashing to ensure a stable cache key regardless
+// of the order returned by filepath.Glob (which is filesystem-dependent).
+func calculateMd5FromAllFilesPerProject(fileList []string) (string, []string, error) {
+	if len(fileList) == 0 {
+		return "", nil, nil
+	}
+
+	// Work on a sorted copy so hash is independent of input/Glob order.
+	sorted := make([]string, len(fileList))
+	copy(sorted, fileList)
+	sort.Strings(sorted)
+
+	hash := md5.New() // #nosec
+	var dirs []string
+	for _, filePath := range sorted {
+		file, err := os.Open(filePath)
+		if err != nil {
+			return "", nil, err
+		}
+		_, err = io.Copy(hash, file)
+		file.Close()
+		if err != nil {
+			return "", nil, err
+		}
+		absDir, err := filepath.Abs(filepath.Dir(filePath))
+		if err != nil {
+			return "", nil, err
+		}
+		dirs = appendIfMissing(dirs, absDir)
+	}
+
+	// Return directories in sorted order for stable, predictable output.
+	sort.Strings(dirs)
+
+	return hex.EncodeToString(hash.Sum(nil)), dirs, nil
 }
 
 func shortestPath(input []string) (shortest string) {

--- a/internal/plugin/autodetect/auto_detect_util_test.go
+++ b/internal/plugin/autodetect/auto_detect_util_test.go
@@ -1,6 +1,8 @@
 package autodetect
 
 import (
+	"crypto/md5" // #nosec
+	"encoding/hex"
 	"os"
 	"path/filepath"
 	"testing"
@@ -129,7 +131,7 @@ func TestDetectDirectoriesToCacheDotnet(t *testing.T) {
 	_, err = f.WriteString(testFileContent)
 	test.Ok(t, err)
 
-	directoriesToCache, buildToolsDetected, _, err := DetectDirectoriesToCache(false)
+	directoriesToCache, buildToolsDetected, hashes, err := DetectDirectoriesToCache(false)
 	test.Ok(t, err)
 	test.Ok(t, os.RemoveAll(csprojFile))
 	test.Ok(t, os.RemoveAll("nuget.config"))
@@ -140,6 +142,7 @@ func TestDetectDirectoriesToCacheDotnet(t *testing.T) {
 
 	test.Equals(t, directoriesToCache, expectedCacheDir)
 	test.Equals(t, buildToolsDetected, expectedDetectedTool)
+	test.Equals(t, hashes, "baab6c16d9143523b7865d46896e4596")
 }
 
 func TestDetectDirectoriesToCacheDotnetWithEnvVar(t *testing.T) {
@@ -196,4 +199,160 @@ func TestDetectDirectoriesToCacheCombined(t *testing.T) {
 	test.Equals(t, directoriesToCache, expectedCacheDir)
 	test.Equals(t, buildToolsDetected, expectedDetectedTool)
 	test.Equals(t, hashes, "1eb00e74bffac0c4fa2d6dbfd8c26cb7baab6c16d9143523b7865d46896e4596")
+}
+
+// --- New tests for per-project .NET auto-detection ---
+
+func TestHashAllFilesPerProjectIfExistNoMatches(t *testing.T) {
+	hash, dirs, err := hashAllFilesPerProjectIfExist("no-such-*.csproj")
+	test.Ok(t, err)
+	test.Equals(t, "", hash)
+	test.Assert(t, dirs == nil, "expected nil dirs for no matches, got %v", dirs)
+}
+
+func TestCalculateMd5FromAllFilesPerProject(t *testing.T) {
+	dir, err := os.MkdirTemp("", "md5all-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	p1 := filepath.Join(dir, "p1")
+	p2 := filepath.Join(dir, "p2")
+	test.Ok(t, os.MkdirAll(p1, 0755))
+	test.Ok(t, os.MkdirAll(p2, 0755))
+
+	f1 := filepath.Join(p1, "a.csproj")
+	f2 := filepath.Join(p2, "b.csproj")
+	content1 := []byte("proj1content")
+	content2 := []byte("proj2content")
+	test.Ok(t, os.WriteFile(f1, content1, 0644))
+	test.Ok(t, os.WriteFile(f2, content2, 0644))
+
+	hash, dirs, err := calculateMd5FromAllFilesPerProject([]string{f1, f2})
+	test.Ok(t, err)
+
+	// compute expected manually (contents are concatenated in sorted path order)
+	h := md5.New() // #nosec
+	_, _ = h.Write(content1)
+	_, _ = h.Write(content2)
+	expectedHash := hex.EncodeToString(h.Sum(nil))
+	test.Equals(t, expectedHash, hash)
+
+	absP1, _ := filepath.Abs(p1)
+	absP2, _ := filepath.Abs(p2)
+	expectedDirs := []string{absP1, absP2}
+	test.Equals(t, expectedDirs, dirs)
+
+	// Hardening check: calling with reversed input must produce identical hash and dirs
+	// (proves we are no longer sensitive to filepath.Glob order).
+	hashRev, dirsRev, err := calculateMd5FromAllFilesPerProject([]string{f2, f1})
+	test.Ok(t, err)
+	test.Equals(t, hash, hashRev)
+	test.Equals(t, dirs, dirsRev)
+
+	// error path
+	_, _, err = calculateMd5FromAllFilesPerProject([]string{filepath.Join(dir, "nope.csproj")})
+	test.NotOk(t, err)
+}
+
+func TestDetectDirectoriesToCacheDotnetMultiProject(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Unsetenv("NUGET_PACKAGES")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	csprojA := "A.csproj"
+	csprojB := "B.csproj"
+	f, err := os.Create(csprojA)
+	test.Ok(t, err)
+	defer f.Close()
+	_, err = f.WriteString(testFileContent)
+	test.Ok(t, err)
+
+	f2, err := os.Create(csprojB)
+	test.Ok(t, err)
+	defer f2.Close()
+	_, err = f2.WriteString(testFileContent2)
+	test.Ok(t, err)
+
+	directoriesToCache, buildToolsDetected, hashes, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	// compute expected using the same helper and Glob order seen by detection
+	matches, _ := filepath.Glob("*.csproj")
+	expectedHash, _, _ := calculateMd5FromAllFilesPerProject(matches)
+
+	test.Ok(t, os.RemoveAll(csprojA))
+	test.Ok(t, os.RemoveAll(csprojB))
+	test.Ok(t, os.RemoveAll("nuget.config"))
+
+	path, _ := filepath.Abs(".nuget/packages")
+	expectedCacheDir := []string{path}
+	expectedDetectedTool := []string{"dotnet"}
+
+	test.Equals(t, directoriesToCache, expectedCacheDir)
+	test.Equals(t, buildToolsDetected, expectedDetectedTool)
+	test.Equals(t, hashes, expectedHash)
+}
+
+func TestDetectDirectoriesToCacheDotnetFsprojOnly(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Unsetenv("NUGET_PACKAGES")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	fsproj := "lib.fsproj"
+	f, err := os.Create(fsproj)
+	test.Ok(t, err)
+	defer f.Close()
+	_, err = f.WriteString(testFileContent)
+	test.Ok(t, err)
+
+	directoriesToCache, buildToolsDetected, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+	test.Ok(t, os.RemoveAll(fsproj))
+	test.Ok(t, os.RemoveAll("nuget.config"))
+
+	path, _ := filepath.Abs(".nuget/packages")
+	expectedCacheDir := []string{path}
+	expectedDetectedTool := []string{"dotnet"}
+
+	test.Equals(t, directoriesToCache, expectedCacheDir)
+	test.Equals(t, buildToolsDetected, expectedDetectedTool)
+}
+
+func TestDetectDirectoriesToCacheDotnetMixedProjectTypes(t *testing.T) {
+	origEnv := os.Getenv("NUGET_PACKAGES")
+	os.Unsetenv("NUGET_PACKAGES")
+	defer os.Setenv("NUGET_PACKAGES", origEnv)
+
+	csproj := "app.csproj"
+	fsproj := "lib.fsproj"
+	f, err := os.Create(csproj)
+	test.Ok(t, err)
+	defer f.Close()
+	_, err = f.WriteString(testFileContent)
+	test.Ok(t, err)
+
+	f2, err := os.Create(fsproj)
+	test.Ok(t, err)
+	defer f2.Close()
+	_, err = f2.WriteString(testFileContent2)
+	test.Ok(t, err)
+
+	directoriesToCache, buildToolsDetected, hashes, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	// compute expected from the csproj glob only (first one processed; later dotnet globs skipped)
+	matches, _ := filepath.Glob("*.csproj")
+	expectedHash, _, _ := calculateMd5FromAllFilesPerProject(matches)
+
+	test.Ok(t, os.RemoveAll(csproj))
+	test.Ok(t, os.RemoveAll(fsproj))
+	test.Ok(t, os.RemoveAll("nuget.config"))
+
+	path, _ := filepath.Abs(".nuget/packages")
+	expectedCacheDir := []string{path}
+	expectedDetectedTool := []string{"dotnet"}
+
+	test.Equals(t, directoriesToCache, expectedCacheDir)
+	test.Equals(t, buildToolsDetected, expectedDetectedTool)
+	test.Equals(t, hashes, expectedHash)
 }


### PR DESCRIPTION
 # CI-16621: Cache intelligence with multi-project .NET repos
  ## Problem
  The auto-detect logic for .NET projects only inspected a single project file (chosen via `shortestPath` on the lexically smallest filename).
  In real solutions containing multiple projects (e.g. `ProjectA/`, `ProjectB/`, `ProjectC-DataAccess/`), this meant:
  - Only one project's NuGet cache directory was ever prepared or cached.
  - The generated cache key was based on the content of only one `.csproj` file.
  - The hash calculation was order-dependent on `filepath.Glob`, leading to flaky/non-deterministic keys across agents.
  As a result, multi-project .NET repositories had poor or broken cache behavior.
  ## Fix
  - Added `usePerProject: true` for `*.csproj`, `*.vbproj` and `*.fsproj` entries.
  - Introduced `hashAllFilesPerProjectIfExist` and `calculateMd5FromAllFilesPerProject` to process **all** matching project files.
  - The dotnet preparer is now called once per project directory. This creates the correct `nuget.config` in each project folder with the right `globalPackagesFolder` (e.g.
  `/harness/ProjectA/.nuget/packages`).
  - Hardened hashing: files are sorted before content is fed to MD5, and returned directories are sorted. This produces stable, reproducible cache keys regardless of filesystem/Glob
  ordering.
  ## Impact
  - Multi-project .NET solutions now get correct per-project caching (demonstrated successfully with `satyakota04/drone-cache:9` image in real pipelines).
  - Single-project .NET repositories see no behavior change.
  - All other languages (Maven, Gradle, Node, Go, Bazel, Yarn, etc.) are unaffected.
  - Cache keys for existing multi-project .NET caches will invalidate on first run after the image upgrade (expected one-time miss).
  - Greatly improves cache hit rate and reliability for complex .NET applications.