### PR TITLE
feat: [CI-23733]: windows 2025 support

### DIFF
--- a/docker/Dockerfile.windows.ltsc2025
+++ b/docker/Dockerfile.windows.ltsc2025
@@ -1,0 +1,13 @@
+# escape=`
+
+# ---------------------------------------------------------------------------
+# drone-cache (meltwater) for Windows Server 2025 (LTSC 2025)
+# ---------------------------------------------------------------------------
+
+FROM plugins/base:windows-ltsc2025-amd64@sha256:9b0c50ee6daca9a5eadef008c0beacf9e7e6f2209eea3260ca687468fb7b3b21
+USER ContainerAdministrator
+
+ENV GODEBUG=netdns=go
+
+ADD release/windows/amd64/drone-cache.exe C:/drone-cache.exe
+ENTRYPOINT [ "C:\\drone-cache.exe" ]

--- a/docker/Dockerfile.windows.ltsc2025.rootless
+++ b/docker/Dockerfile.windows.ltsc2025.rootless
@@ -1,0 +1,9 @@
+# escape=`
+
+FROM plugins/base:windows-ltsc2025-amd64@sha256:9b0c50ee6daca9a5eadef008c0beacf9e7e6f2209eea3260ca687468fb7b3b21
+USER ContainerUser
+
+ENV GODEBUG=netdns=go
+
+ADD release/windows/amd64/drone-cache.exe C:/drone-cache.exe
+ENTRYPOINT [ "C:\\drone-cache.exe" ]

--- a/docker/manifest.rootless.tmpl
+++ b/docker/manifest.rootless.tmpl
@@ -29,3 +29,9 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  -
+    image: plugins/cache:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2025-amd64-rootless
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025

--- a/docker/manifest.tmpl
+++ b/docker/manifest.tmpl
@@ -47,3 +47,9 @@ manifests:
       architecture: amd64
       os: windows
       version: ltsc2022
+  -
+    image: plugins/cache:{{#if build.tag}}{{trimPrefix "v" build.tag}}-{{/if}}windows-ltsc2025-amd64
+    platform:
+      architecture: amd64
+      os: windows
+      version: ltsc2025


### PR DESCRIPTION
This pull request adds support for Windows Server 2025 (LTSC 2025) to the build and release process for the `drone-cache` plugin. The main changes include new Dockerfiles for both standard and rootless builds on Windows LTSC 2025, as well as updates to the manifest templates to publish these images.

**Windows LTSC 2025 Support:**

* Added `docker/Dockerfile.windows.ltsc2025` for building the standard `drone-cache` image on Windows Server 2025 with the appropriate base image and configuration.
* Added `docker/Dockerfile.windows.ltsc2025.rootless` for building the rootless variant of the `drone-cache` image on Windows Server 2025.

**Manifest and Release Pipeline Updates:**

* Updated `docker/manifest.tmpl` to include the new Windows LTSC 2025 image in the published manifests.
* Updated `docker/manifest.rootless.tmpl` to include the new Windows LTSC 2025 rootless image in the published manifests.
<img width="1399" height="211" alt="Screenshot 2026-07-14 at 3 18 38 PM" src="https://github.com/user-attachments/assets/1acb5478-19c8-4d1e-9de6-8a94f4934976" />
<img width="1419" height="420" alt="Screenshot 2026-07-14 at 3 20 19 PM" src="https://github.com/user-attachments/assets/8248b6c4-ef2b-4d17-8205-1c378956d8d0" />
<img width="1642" height="990" alt="Screenshot 2026-07-14 at 3 24 13 PM" src="https://github.com/user-attachments/assets/c42fd3b4-544c-4b48-b9b8-7d19a13e6e42" />
