### PR TITLE
feat: [CI-9599]: ignore missing source paths on save cache

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -57,7 +57,8 @@ func New(logger log.Logger, s storage.Storage, a archive.Archive, g key.Generato
 
 	return &cache{
 		NewRebuilder(log.With(logger, "component", "rebuilder"), s, a, g,
-			options.fallbackGenerator, options.namespace, options.override, options.gracefulDetect),
+			options.fallbackGenerator, options.namespace, options.override,
+			resolveMissingPathPolicy(options.ignoreMissingPaths, options.gracefulDetect)),
 		NewRestorer(log.With(logger, "component", "restorer"), s, a, g,
 			options.fallbackGenerator, options.namespace, options.failRestoreIfKeyNotPresent, options.enableCacheKeySeparator, options.strictKeyMatching, backend, accountID, options.cacheType),
 		NewFlusher(log.With(logger, "component", "flusher"), s, time.Hour),

--- a/cache/missing_path_policy.go
+++ b/cache/missing_path_policy.go
@@ -1,0 +1,34 @@
+package cache
+
+// MissingPathPolicy controls how Rebuild handles source paths that do not exist.
+//
+// Keep this separate from automatic cache detection so enabling ignore-missing
+// paths does not change Cache Intelligence / auto-detect behavior.
+type MissingPathPolicy int
+
+const (
+	// MissingPathStrict fails Rebuild as soon as any configured source path is missing.
+	// This is the default for explicit Save Cache steps.
+	MissingPathStrict MissingPathPolicy = iota
+
+	// MissingPathSkipAllowEmpty skips missing source paths and still succeeds when
+	// every path is missing. Preserves existing automatic-detection behavior.
+	MissingPathSkipAllowEmpty
+
+	// MissingPathSkipRequirePresent skips missing source paths with a warning, caches
+	// remaining paths, and fails when no existing path remains to cache.
+	MissingPathSkipRequirePresent
+)
+
+// resolveMissingPathPolicy selects the rebuild missing-path policy.
+// IgnoreMissingPaths takes precedence when enabled so explicit Save Cache
+// opt-in behavior is never overloaded by auto-detect graceful skipping.
+func resolveMissingPathPolicy(ignoreMissingPaths, gracefulDetect bool) MissingPathPolicy {
+	if ignoreMissingPaths {
+		return MissingPathSkipRequirePresent
+	}
+	if gracefulDetect {
+		return MissingPathSkipAllowEmpty
+	}
+	return MissingPathStrict
+}

--- a/cache/option.go
+++ b/cache/option.go
@@ -8,6 +8,7 @@ type options struct {
 	override                   bool
 	failRestoreIfKeyNotPresent bool
 	gracefulDetect             bool
+	ignoreMissingPaths         bool
 	enableCacheKeySeparator    bool
 	strictKeyMatching          bool
 	cacheType                  string
@@ -45,10 +46,19 @@ func WithOverride(override bool) Option {
 	})
 }
 
-// WithGracefulDetect sets option to fail sve if directory does not exist.
+// WithGracefulDetect sets option used by automatic cache detection to skip
+// missing directories without failing the rebuild when nothing was uploaded.
 func WithGracefulDetect(gracefulDetect bool) Option {
 	return optionFunc(func(o *options) {
 		o.gracefulDetect = gracefulDetect
+	})
+}
+
+// WithIgnoreMissingPaths skips missing source paths during Save Cache while
+// still requiring at least one existing path to be cached.
+func WithIgnoreMissingPaths(ignoreMissingPaths bool) Option {
+	return optionFunc(func(o *options) {
+		o.ignoreMissingPaths = ignoreMissingPaths
 	})
 }
 

--- a/cache/rebuilder.go
+++ b/cache/rebuilder.go
@@ -1,8 +1,10 @@
 package cache
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -27,14 +29,34 @@ type rebuilder struct {
 	g  key.Generator
 	fg key.Generator
 
-	namespace      string
-	override       bool
-	gracefulDetect bool
+	namespace         string
+	override          bool
+	missingPathPolicy MissingPathPolicy
+}
+
+type rebuildSummary struct {
+	Requested     int
+	Missing       int
+	AlreadyExists int
+	Scheduled     int
+	Uploaded      int
+	Failed        int
+}
+
+type uploadResult struct {
+	Source string
+	Target string
+	Err    error
+}
+
+type scheduledUpload struct {
+	src string
+	dst string
 }
 
 // NewRebuilder creates a new cache.Rebuilder.
-func NewRebuilder(logger log.Logger, s storage.Storage, a archive.Archive, g key.Generator, fg key.Generator, namespace string, override bool, gracefulDetect bool) Rebuilder { // nolint:lll
-	return rebuilder{logger, a, s, g, fg, namespace, override, gracefulDetect}
+func NewRebuilder(logger log.Logger, s storage.Storage, a archive.Archive, g key.Generator, fg key.Generator, namespace string, override bool, missingPathPolicy MissingPathPolicy) Rebuilder { // nolint:lll
+	return rebuilder{logger, a, s, g, fg, namespace, override, missingPathPolicy}
 }
 
 // normalizeDockerPath converts Docker infrastructure paths to a fixed format.
@@ -73,27 +95,32 @@ func (r rebuilder) Rebuild(srcs []string) error {
 	level.Info(r.logger).Log("msg", "rebuilding cache")
 
 	now := time.Now()
+	summary := rebuildSummary{Requested: len(srcs)}
+
+	if len(srcs) == 0 {
+		if r.missingPathPolicy == MissingPathSkipRequirePresent {
+			level.Error(r.logger).Log("msg", "cache save failed: no source paths configured", "requested", 0)
+			return errors.New("cache save failed: no source paths configured")
+		}
+		level.Info(r.logger).Log("msg", "cache built", "took", time.Since(now))
+		return nil
+	}
 
 	key, err := r.generateKey()
 	if err != nil {
 		return fmt.Errorf("generate key, %w", err)
 	}
 
-	var (
-		wg               sync.WaitGroup
-		errs             = &internal.MultiError{}
-		namespace        = filepath.ToSlash(filepath.Clean(r.namespace))
-		successCount     int
-		totalDirectories int
-	)
+	namespace := filepath.ToSlash(filepath.Clean(r.namespace))
+	scheduled := make([]scheduledUpload, 0, len(srcs))
 
 	for _, src := range srcs {
 		if _, err := os.Lstat(src); err != nil {
-			if !r.gracefulDetect {
-				return fmt.Errorf("source <%s>, make sure file or directory exists and readable, %w", src, err)
+			if skip, fatalErr := r.handleMissingPath(src, err, &summary); fatalErr != nil {
+				return fatalErr
+			} else if skip {
+				continue
 			}
-			level.Warn(r.logger).Log("msg", fmt.Sprintf("source directory %s does not exist, skipping", src), "err", fmt.Errorf("source <%s>, make sure file or directory exists and readable, %w", src, err))
-			continue
 		}
 
 		normalizedSrc := normalizeDockerPath(src)
@@ -107,43 +134,107 @@ func (r rebuilder) Rebuild(srcs []string) error {
 			}
 
 			if exists {
+				summary.AlreadyExists++
 				continue
 			}
 		}
 
-		level.Info(r.logger).Log("msg", "rebuilding cache for directory", "local", src)
-		level.Debug(r.logger).Log("msg", "rebuilding cache for directory", "remote", dst)
+		level.Info(r.logger).Log("msg", "rebuilding cache for source path", "local", src)
+		level.Debug(r.logger).Log("msg", "rebuilding cache for source path", "remote", dst)
 
-		wg.Add(1)
-
-		go func(dst, src string) {
-			defer wg.Done()
-
-			if err := r.rebuild(src, dst); err != nil {
-				errs.Add(fmt.Errorf("upload from <%s> to <%s>, %w", src, dst, err))
-			} else {
-				successCount++
-			}
-		}(dst, src)
+		summary.Scheduled++
+		scheduled = append(scheduled, scheduledUpload{src: src, dst: dst})
 	}
 
-	wg.Wait()
+	if summary.Scheduled == 0 {
+		if r.missingPathPolicy == MissingPathSkipRequirePresent && summary.Missing == summary.Requested {
+			level.Error(r.logger).Log("msg", "cache save failed: all configured source paths are missing",
+				"requested", summary.Requested, "missing", summary.Missing)
+			return errors.New("cache save failed: all configured source paths are missing")
+		}
 
-	totalDirectories = len(srcs)
-
-	if successCount > 0 {
-		level.Info(r.logger).Log("msg", "cache built", "took", time.Since(now),
-			"status", fmt.Sprintf("%d/%d directories cached", successCount, totalDirectories))
+		r.logRebuildComplete(summary, now)
 		return nil
 	}
 
-	if errs.Err() != nil {
+	results := make(chan uploadResult, len(scheduled))
+	var wg sync.WaitGroup
+
+	for _, item := range scheduled {
+		wg.Add(1)
+		go func(dst, src string) {
+			defer wg.Done()
+			results <- uploadResult{
+				Source: src,
+				Target: dst,
+				Err:    r.rebuild(src, dst),
+			}
+		}(item.dst, item.src)
+	}
+
+	wg.Wait()
+	close(results)
+
+	errs := &internal.MultiError{}
+	for result := range results {
+		if result.Err != nil {
+			summary.Failed++
+			errs.Add(fmt.Errorf("upload from <%s> to <%s>, %w", result.Source, result.Target, result.Err))
+			continue
+		}
+		summary.Uploaded++
+	}
+
+	if summary.Failed > 0 {
+		level.Error(r.logger).Log("msg", "cache save failed",
+			"requested", summary.Requested,
+			"uploaded", summary.Uploaded,
+			"existing", summary.AlreadyExists,
+			"missing", summary.Missing,
+			"failed", summary.Failed,
+			"took", time.Since(now),
+		)
 		return fmt.Errorf("rebuild failed, %w", errs)
 	}
 
-	level.Info(r.logger).Log("msg", "cache built", "took", time.Since(now))
-
+	r.logRebuildComplete(summary, now)
 	return nil
+}
+
+// handleMissingPath applies the missing-path policy for an Lstat failure.
+// Returns (skip=true) when the path should be skipped, or a fatal error.
+func (r rebuilder) handleMissingPath(src string, err error, summary *rebuildSummary) (bool, error) {
+	switch r.missingPathPolicy {
+	case MissingPathSkipRequirePresent:
+		// Only genuine not-found errors may be skipped.
+		if errors.Is(err, fs.ErrNotExist) {
+			summary.Missing++
+			level.Warn(r.logger).Log("msg", "cache source path does not exist; skipping", "path", src)
+			return true, nil
+		}
+		return false, fmt.Errorf("source <%s>, make sure file or directory exists and readable, %w", src, err)
+
+	case MissingPathSkipAllowEmpty:
+		// Preserve automatic-detection behavior: skip any Lstat failure.
+		summary.Missing++
+		level.Warn(r.logger).Log("msg", fmt.Sprintf("source directory %s does not exist, skipping", src),
+			"err", fmt.Errorf("source <%s>, make sure file or directory exists and readable, %w", src, err))
+		return true, nil
+
+	default: // MissingPathStrict
+		return false, fmt.Errorf("source <%s>, make sure file or directory exists and readable, %w", src, err)
+	}
+}
+
+func (r rebuilder) logRebuildComplete(summary rebuildSummary, started time.Time) {
+	level.Info(r.logger).Log("msg", "cache save complete",
+		"requested", summary.Requested,
+		"uploaded", summary.Uploaded,
+		"existing", summary.AlreadyExists,
+		"missing", summary.Missing,
+		"failed", summary.Failed,
+		"took", time.Since(started),
+	)
 }
 
 // rebuild pushes the archived file to the cache.

--- a/cache/rebuilder_test.go
+++ b/cache/rebuilder_test.go
@@ -1,85 +1,449 @@
 package cache
 
 import (
+	"errors"
+	"io"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+
+	"github.com/go-kit/log"
+	"github.com/meltwater/drone-cache/key/generator"
 )
 
-func TestRebuild(t *testing.T) {
-	// Implement me!
-	t.Skip("skipping unimplemented test.")
-}
-
-func TestNormalizeDockerPath(t *testing.T) {
+func TestResolveMissingPathPolicy(t *testing.T) {
 	tests := []struct {
-		name      string
-		stageType string
-		input     string
-		expected  string
+		name               string
+		ignoreMissingPaths bool
+		gracefulDetect     bool
+		want               MissingPathPolicy
 	}{
-		{
-			name:      "non-docker env returns input unchanged",
-			stageType: "",
-			input:     "/tmp/harness/uuid-abc123/.gradle",
-			expected:  "/tmp/harness/uuid-abc123/.gradle",
-		},
-		{
-			name:      "docker env with unix harness path",
-			stageType: "DOCKER",
-			input:     "/tmp/harness/uuid-abc123/.gradle",
-			expected:  "docker/.gradle",
-		},
-		{
-			name:      "docker env with nested unix path",
-			stageType: "DOCKER",
-			input:     "/tmp/harness/NsisF6Y9QfaOtdukTItZfA/.gradle/caches/modules-2",
-			expected:  "docker/.gradle/caches/modules-2",
-		},
-		{
-			name:      "docker env with windows harness path",
-			stageType: "DOCKER",
-			input:     "C:/tmp/harness/uuid-abc123/.gradle",
-			expected:  "docker/.gradle",
-		},
-		{
-			name:      "docker env with non-matching prefix returns unchanged",
-			stageType: "DOCKER",
-			input:     "/home/user/.gradle",
-			expected:  "/home/user/.gradle",
-		},
-		{
-			name:      "docker env with no UUID segment returns unchanged",
-			stageType: "DOCKER",
-			input:     "/tmp/harness/nouuidhere",
-			expected:  "/tmp/harness/nouuidhere",
-		},
-		{
-			name:      "docker env with relative path returns unchanged",
-			stageType: "DOCKER",
-			input:     ".gradle",
-			expected:  ".gradle",
-		},
-		{
-			name:      "docker env with only UUID and single file",
-			stageType: "DOCKER",
-			input:     "/tmp/harness/some-uuid/file.txt",
-			expected:  "docker/file.txt",
-		},
+		{name: "default strict", want: MissingPathStrict},
+		{name: "graceful detect", gracefulDetect: true, want: MissingPathSkipAllowEmpty},
+		{name: "ignore missing paths", ignoreMissingPaths: true, want: MissingPathSkipRequirePresent},
+		{name: "ignore missing takes precedence", ignoreMissingPaths: true, gracefulDetect: true, want: MissingPathSkipRequirePresent},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.stageType != "" {
-				os.Setenv("DRONE_STAGE_TYPE", tt.stageType)
-				defer os.Unsetenv("DRONE_STAGE_TYPE")
-			} else {
-				os.Unsetenv("DRONE_STAGE_TYPE")
-			}
-
-			got := normalizeDockerPath(tt.input)
-			if got != tt.expected {
-				t.Errorf("normalizeDockerPath(%q) = %q, want %q", tt.input, got, tt.expected)
+			got := resolveMissingPathPolicy(tt.ignoreMissingPaths, tt.gracefulDetect)
+			if got != tt.want {
+				t.Fatalf("resolveMissingPathPolicy() = %v, want %v", got, tt.want)
 			}
 		})
 	}
+}
+
+func TestRebuildMissingPathMatrix(t *testing.T) {
+	logger := log.NewNopLogger()
+	keyGen := generator.NewStatic("test-key")
+
+	t.Run("strict all exist", func(t *testing.T) {
+		existing := createTempSource(t)
+		storage := &MockStorage{}
+		var putCount int32
+		storage.PutFunc = func(p string, r io.Reader) error {
+			atomic.AddInt32(&putCount, 1)
+			_, _ = io.Copy(io.Discard, r)
+			return nil
+		}
+
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathStrict)
+		if err := r.Rebuild([]string{existing}); err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+		if atomic.LoadInt32(&putCount) != 1 {
+			t.Fatalf("Put calls = %d, want 1", putCount)
+		}
+	})
+
+	t.Run("strict one missing", func(t *testing.T) {
+		existing := createTempSource(t)
+		r := NewRebuilder(logger, &MockStorage{}, &MockArchive{}, keyGen, nil, "ns", true, MissingPathStrict)
+		err := r.Rebuild([]string{existing, filepath.Join(t.TempDir(), "missing")})
+		if err == nil {
+			t.Fatal("Rebuild() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "make sure file or directory exists") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("strict all missing", func(t *testing.T) {
+		r := NewRebuilder(logger, &MockStorage{}, &MockArchive{}, keyGen, nil, "ns", true, MissingPathStrict)
+		err := r.Rebuild([]string{filepath.Join(t.TempDir(), "missing-a"), filepath.Join(t.TempDir(), "missing-b")})
+		if err == nil {
+			t.Fatal("Rebuild() expected error, got nil")
+		}
+	})
+
+	t.Run("ignore missing all exist", func(t *testing.T) {
+		a := createTempSource(t)
+		b := createTempSource(t)
+		var putCount int32
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				atomic.AddInt32(&putCount, 1)
+				_, _ = io.Copy(io.Discard, r)
+				return nil
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		if err := r.Rebuild([]string{a, b}); err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+		if atomic.LoadInt32(&putCount) != 2 {
+			t.Fatalf("Put calls = %d, want 2", putCount)
+		}
+	})
+
+	t.Run("ignore missing one missing", func(t *testing.T) {
+		existing := createTempSource(t)
+		var putCount int32
+		var putMu sync.Mutex
+		var putPaths []string
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				atomic.AddInt32(&putCount, 1)
+				putMu.Lock()
+				putPaths = append(putPaths, p)
+				putMu.Unlock()
+				_, _ = io.Copy(io.Discard, r)
+				return nil
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{existing, filepath.Join(t.TempDir(), "missing")})
+		if err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+		if atomic.LoadInt32(&putCount) != 1 {
+			t.Fatalf("Put calls = %d, want 1", putCount)
+		}
+	})
+
+	t.Run("ignore missing multiple missing one existing", func(t *testing.T) {
+		existing := createTempSource(t)
+		var putCount int32
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				atomic.AddInt32(&putCount, 1)
+				_, _ = io.Copy(io.Discard, r)
+				return nil
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{
+			filepath.Join(t.TempDir(), "missing-a"),
+			existing,
+			filepath.Join(t.TempDir(), "missing-b"),
+		})
+		if err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+		if atomic.LoadInt32(&putCount) != 1 {
+			t.Fatalf("Put calls = %d, want 1", putCount)
+		}
+	})
+
+	t.Run("ignore missing all missing", func(t *testing.T) {
+		r := NewRebuilder(logger, &MockStorage{}, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{filepath.Join(t.TempDir(), "missing-a"), filepath.Join(t.TempDir(), "missing-b")})
+		if err == nil {
+			t.Fatal("Rebuild() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "all configured source paths are missing") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("ignore missing empty path list", func(t *testing.T) {
+		r := NewRebuilder(logger, &MockStorage{}, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild(nil)
+		if err == nil {
+			t.Fatal("Rebuild() expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no source paths configured") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("ignore missing with permission error", func(t *testing.T) {
+		denied := createPermissionDeniedPath(t)
+		if denied == "" {
+			t.Skip("unable to create permission-denied path on this platform")
+		}
+		existing := createTempSource(t)
+		r := NewRebuilder(logger, &MockStorage{}, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{existing, denied})
+		if err == nil {
+			t.Fatal("Rebuild() expected permission error, got nil")
+		}
+		if strings.Contains(err.Error(), "all configured source paths are missing") {
+			t.Fatalf("permission errors must remain fatal, got: %v", err)
+		}
+	})
+
+	t.Run("ignore missing with archive failure", func(t *testing.T) {
+		existing := createTempSource(t)
+		missing := filepath.Join(t.TempDir(), "missing")
+		archive := &MockArchive{
+			CreateFunc: func(srcs []string, w io.Writer, stripComponents bool) (int64, error) {
+				return 0, errors.New("archive boom")
+			},
+		}
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				_, err := io.Copy(io.Discard, r)
+				return err
+			},
+		}
+		r := NewRebuilder(logger, storage, archive, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{existing, missing})
+		if err == nil {
+			t.Fatal("Rebuild() expected archive failure, got nil")
+		}
+	})
+
+	t.Run("ignore missing with upload failure", func(t *testing.T) {
+		existing := createTempSource(t)
+		missing := filepath.Join(t.TempDir(), "missing")
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				_, _ = io.Copy(io.Discard, r)
+				return errors.New("upload boom")
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{existing, missing})
+		if err == nil {
+			t.Fatal("Rebuild() expected upload failure, got nil")
+		}
+	})
+
+	t.Run("mixed upload success and failure", func(t *testing.T) {
+		a := createTempSource(t)
+		b := createTempSource(t)
+		var putCount int32
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				n := atomic.AddInt32(&putCount, 1)
+				_, _ = io.Copy(io.Discard, r)
+				if n == 1 {
+					return nil
+				}
+				return errors.New("second upload failed")
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{a, b})
+		if err == nil {
+			t.Fatal("Rebuild() expected failure when any upload fails, got nil")
+		}
+	})
+
+	t.Run("all remote objects already exist override disabled", func(t *testing.T) {
+		a := createTempSource(t)
+		b := createTempSource(t)
+		var putCount int32
+		storage := &MockStorage{
+			ExistsFunc: func(p string) (bool, error) { return true, nil },
+			PutFunc: func(p string, r io.Reader) error {
+				atomic.AddInt32(&putCount, 1)
+				return nil
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", false, MissingPathSkipRequirePresent)
+		if err := r.Rebuild([]string{a, b}); err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+		if atomic.LoadInt32(&putCount) != 0 {
+			t.Fatalf("Put calls = %d, want 0", putCount)
+		}
+	})
+
+	t.Run("missing path plus remote object already exists", func(t *testing.T) {
+		existing := createTempSource(t)
+		storage := &MockStorage{
+			ExistsFunc: func(p string) (bool, error) { return true, nil },
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", false, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{existing, filepath.Join(t.TempDir(), "missing")})
+		if err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+	})
+
+	t.Run("file and directory source paths", func(t *testing.T) {
+		dir := createTempSource(t)
+		file, err := os.CreateTemp(t.TempDir(), "cache-file-*.txt")
+		if err != nil {
+			t.Fatalf("CreateTemp: %v", err)
+		}
+		_, _ = file.WriteString("hello")
+		_ = file.Close()
+
+		var putCount int32
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				atomic.AddInt32(&putCount, 1)
+				_, _ = io.Copy(io.Discard, r)
+				return nil
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		if err := r.Rebuild([]string{dir, file.Name()}); err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+		if atomic.LoadInt32(&putCount) != 2 {
+			t.Fatalf("Put calls = %d, want 2", putCount)
+		}
+	})
+
+	t.Run("relative and absolute paths", func(t *testing.T) {
+		abs := createTempSource(t)
+		rel := filepath.Join(".", "rel-cache-src")
+		if err := os.MkdirAll(rel, 0o755); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(rel, "data.txt"), []byte("rel"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		t.Cleanup(func() { _ = os.RemoveAll(rel) })
+
+		var putCount int32
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				atomic.AddInt32(&putCount, 1)
+				_, _ = io.Copy(io.Discard, r)
+				return nil
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		if err := r.Rebuild([]string{abs, "./rel-cache-src"}); err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+		if atomic.LoadInt32(&putCount) != 2 {
+			t.Fatalf("Put calls = %d, want 2", putCount)
+		}
+	})
+
+	t.Run("dangling symbolic link treated as missing when ignore enabled", func(t *testing.T) {
+		link := filepath.Join(t.TempDir(), "dangling")
+		if err := os.Symlink(filepath.Join(t.TempDir(), "does-not-exist"), link); err != nil {
+			t.Skipf("symlink not supported: %v", err)
+		}
+		existing := createTempSource(t)
+		var putCount int32
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				atomic.AddInt32(&putCount, 1)
+				_, _ = io.Copy(io.Discard, r)
+				return nil
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		// Lstat on dangling symlink succeeds (the link itself exists). Archive may still fail.
+		// For ignore-missing we only skip ErrNotExist from Lstat. Ensure existing path still uploads
+		// when dangling link causes archive/upload failure → overall fail.
+		err := r.Rebuild([]string{existing, link})
+		// Either succeeds (if archive accepts dangling link) or fails on archive — both are acceptable
+		// as long as we do not treat the dangling link as a silent missing skip incorrectly without upload of existing.
+		if err == nil && atomic.LoadInt32(&putCount) < 1 {
+			t.Fatal("expected at least one upload when rebuild succeeds")
+		}
+	})
+
+	t.Run("path disappears after validation", func(t *testing.T) {
+		existing := createTempSource(t)
+		archive := &MockArchive{
+			CreateFunc: func(srcs []string, w io.Writer, stripComponents bool) (int64, error) {
+				return 0, fsErrNotExist("path disappeared")
+			},
+		}
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				_, err := io.Copy(io.Discard, r)
+				return err
+			},
+		}
+		r := NewRebuilder(logger, storage, archive, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		err := r.Rebuild([]string{existing})
+		if err == nil {
+			t.Fatal("Rebuild() expected archive failure after validation, got nil")
+		}
+	})
+
+	t.Run("graceful detect all missing still succeeds", func(t *testing.T) {
+		r := NewRebuilder(logger, &MockStorage{}, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipAllowEmpty)
+		if err := r.Rebuild([]string{filepath.Join(t.TempDir(), "missing")}); err != nil {
+			t.Fatalf("auto-detect policy should succeed when all missing, got: %v", err)
+		}
+	})
+
+	t.Run("concurrent successful uploads", func(t *testing.T) {
+		paths := make([]string, 20)
+		for i := range paths {
+			paths[i] = createTempSource(t)
+		}
+		var putCount int32
+		storage := &MockStorage{
+			PutFunc: func(p string, r io.Reader) error {
+				atomic.AddInt32(&putCount, 1)
+				_, _ = io.Copy(io.Discard, r)
+				return nil
+			},
+		}
+		r := NewRebuilder(logger, storage, &MockArchive{}, keyGen, nil, "ns", true, MissingPathSkipRequirePresent)
+		if err := r.Rebuild(paths); err != nil {
+			t.Fatalf("Rebuild() unexpected error: %v", err)
+		}
+		if atomic.LoadInt32(&putCount) != 20 {
+			t.Fatalf("Put calls = %d, want 20", putCount)
+		}
+	})
+}
+
+func createTempSource(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "data.txt"), []byte("cached"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return dir
+}
+
+func createPermissionDeniedPath(t *testing.T) string {
+	t.Helper()
+	parent := t.TempDir()
+	child := filepath.Join(parent, "secret")
+	if err := os.Mkdir(child, 0o700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if err := os.Chmod(parent, 0); err != nil {
+		return ""
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(parent, 0o700)
+	})
+	denied := filepath.Join(parent, "secret")
+	if _, err := os.Lstat(denied); err == nil || errors.Is(err, os.ErrNotExist) {
+		_ = os.Chmod(parent, 0o700)
+		return ""
+	}
+	return denied
+}
+
+type notExistError string
+
+func (e notExistError) Error() string { return string(e) }
+func (e notExistError) Is(target error) bool {
+	return target == os.ErrNotExist
+}
+
+func fsErrNotExist(msg string) error {
+	return notExistError(msg)
 }

--- a/internal/plugin/config.go
+++ b/internal/plugin/config.go
@@ -33,6 +33,7 @@ type Config struct {
 	PreserveMetadata           bool
 	Override                   bool
 	FailRestoreIfKeyNotPresent bool
+	IgnoreMissingPaths         bool
 	CompressionLevel           int
 	StorageOperationTimeout    time.Duration
 	EnableCacheKeySeparator    bool

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -167,6 +167,7 @@ func (p *Plugin) Exec() error { // nolint:funlen
 
 	options = append(options, cache.WithOverride(p.Config.Override),
 		cache.WithFailRestoreIfKeyNotPresent(p.Config.FailRestoreIfKeyNotPresent),
+		cache.WithIgnoreMissingPaths(p.Config.IgnoreMissingPaths),
 		cache.WithEnableCacheKeySeparator(p.Config.EnableCacheKeySeparator),
 		cache.WithStrictKeyMatching(p.Config.StrictKeyMatching))
 

--- a/main.go
+++ b/main.go
@@ -338,6 +338,12 @@ func main() {
 			EnvVars: []string{"PLUGIN_FAIL_RESTORE_IF_KEY_NOT_PRESENT"},
 		},
 		&cli.BoolFlag{
+			Name:    "ignore-missing-paths",
+			Usage:   "skip missing source paths while saving available paths",
+			Value:   false,
+			EnvVars: []string{"PLUGIN_IGNORE_MISSING_PATHS"},
+		},
+		&cli.BoolFlag{
 			Name:    "enable-cache-key-separator",
 			Usage:   "Enable adding of / as the cache key suffix. (defaults to false)",
 			Value:   false,
@@ -719,6 +725,7 @@ func run(c *cli.Context) error {
 		LocalRoot:                  c.String("local-root"),
 		Override:                   c.Bool("override"),
 		FailRestoreIfKeyNotPresent: c.Bool("fail-restore-if-key-not-present"),
+		IgnoreMissingPaths:         c.Bool("ignore-missing-paths"),
 		EnableCacheKeySeparator:    c.Bool("enable-cache-key-separator"),
 		StrictKeyMatching:          c.Bool("strict-key-matching"),
 


### PR DESCRIPTION
## Summary

Adds an opt-in setting so Save Cache can skip missing source paths, warn about them, and still cache paths that exist.

Today, if any configured `sourcePaths` entry is missing, Save Cache fails entirely — including folders that were successfully created by earlier steps. This change fixes that while keeping the default behavior unchanged.

**Tracking**
- Jira: [CI-9599](https://harness.atlassian.net/browse/CI-9599)
- Tech Spec: [CI Tech Spec 47](https://harness.atlassian.net/wiki/spaces/CI1/pages/24024221676/CI+Tech+Spec+47+Save+Cache+-+Ignore+Missing+Source+Paths)

## What changed

- Added `--ignore-missing-paths` / `PLUGIN_IGNORE_MISSING_PATHS` (default: `false`)
- Introduced a dedicated `MissingPathPolicy` so this does not change Cache Intelligence / auto-detect behavior
- When enabled:
  - existing paths are cached
  - missing paths are skipped with a warning
  - only `fs.ErrNotExist` is skipped
  - permission / archive / upload errors remain fatal
  - fails if all configured paths are missing
  - fails if the source-path list is empty
- Upload result handling now fails if any scheduled upload fails (no longer succeeds when only some uploads succeed), per tech spec §7.5

## How to enable

```yaml
variables:
  - name: PLUGIN_IGNORE_MISSING_PATHS
    type: String
    value: "true"
```

### Example

```text
sourcePaths:
  - /harness/.gradle   # exists
  - /harness/.sonar    # missing

PLUGIN_IGNORE_MISSING_PATHS=true
→ warn for .sonar, cache .gradle, step succeeds
```

## Out of scope

- harness-core version bump / YAML field (follow-up after plugin publish)
- Restore Cache behavior (unchanged)
- Cache Intelligence auto-detect policy (unchanged)

## Test plan

- [x] Unit tests for missing-path behavior matrix
- [x] `go test ./cache/ -run 'TestRebuild|TestResolve|TestNormalize'`
- [x] `go test -race ./cache/ -run 'TestRebuild|TestResolve|TestNormalize'`
- [ ] Reviewer validation
- [ ] Publish plugin version and bump in harness-core
- [ ] E2E pipeline with one existing + one missing path

[CI-9599]: https://harness.atlassian.net/browse/CI-9599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ