### PR TITLE
feat:[CI-21400]: added the additional arguments in the api to cache s…

### DIFF
--- a/harness/http.go
+++ b/harness/http.go
@@ -62,6 +62,10 @@ type HTTPClient struct {
 	Endpoint    string
 	AccountID   string
 	BearerToken string
+	OrgID       string
+	ProjectID   string
+	PipelineID  string
+	StageID     string
 	Logger      log.Logger
 }
 
@@ -135,8 +139,7 @@ func (c *HTTPClient) GetEntriesList(ctx context.Context, prefix string) ([]commo
 	path := c.buildEndpointPath(ListEntriesEndpoint, prefix)
 	fullURL := c.Endpoint + path
 
-	// Add backend query parameter based on environment variable
-	fullURL = c.addBackendParameter(fullURL)
+	fullURL = c.addRequestParameters(fullURL)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
 	if err != nil {
@@ -202,8 +205,7 @@ func (c *HTTPClient) GetEntriesListForType(ctx context.Context, cacheType string
 	q.Set("cacheType", cacheType)
 	fullURL := c.appendQuery(baseURL, q)
 
-	// Add backend query parameter based on environment variable
-	fullURL = c.addBackendParameter(fullURL)
+	fullURL = c.addRequestParameters(fullURL)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
 	if err != nil {
@@ -232,8 +234,7 @@ func (c *HTTPClient) GetEntriesListForType(ctx context.Context, cacheType string
 }
 
 func (c *HTTPClient) getLink(ctx context.Context, path string) (string, error) {
-	// Add backend query parameter based on environment variable
-	path = c.addBackendParameter(path)
+	path = c.addRequestParameters(path)
 
 	req, err := http.NewRequestWithContext(ctx, "GET", path, nil)
 	if err != nil {
@@ -284,6 +285,25 @@ func (c *HTTPClient) addBackendParameter(urlStr string) string {
 		}
 	}
 	return urlStr
+}
+
+func (c *HTTPClient) addRequestParameters(urlStr string) string {
+	urlStr = c.addBackendParameter(urlStr)
+
+	context := url.Values{}
+	if c.OrgID != "" {
+		context.Set("orgId", c.OrgID)
+	}
+	if c.ProjectID != "" {
+		context.Set("projectId", c.ProjectID)
+	}
+	if c.PipelineID != "" {
+		context.Set("pipelineId", c.PipelineID)
+	}
+	if c.StageID != "" {
+		context.Set("stageId", c.StageID)
+	}
+	return c.appendQuery(urlStr, context)
 }
 
 // appendQuery appends the provided query values to the given URL string.

--- a/harness/http_test.go
+++ b/harness/http_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"testing"
@@ -83,7 +84,7 @@ func TestURLConstruction(t *testing.T) {
 	os.Setenv("HARNESS_CI_USE_GCS_CACHE_SERVICE", "false")
 	path := client.buildEndpointPath(StoreEndpoint, "test-key")
 	fullURL := client.Endpoint + path
-	
+
 	backend := client.getBackendType()
 	if backend != "" {
 		if strings.Contains(fullURL, "?") {
@@ -102,7 +103,7 @@ func TestURLConstruction(t *testing.T) {
 	os.Setenv("HARNESS_CI_USE_GCS_CACHE_SERVICE", "true")
 	path = client.buildEndpointPath(StoreEndpoint, "test-key")
 	fullURL = client.Endpoint + path
-	
+
 	backend = client.getBackendType()
 	if backend != "" {
 		if strings.Contains(fullURL, "?") {
@@ -119,4 +120,90 @@ func TestURLConstruction(t *testing.T) {
 
 	// Cleanup
 	os.Unsetenv("HARNESS_CI_USE_GCS_CACHE_SERVICE")
+}
+
+func TestAddRequestParameters(t *testing.T) {
+	t.Setenv("HARNESS_CI_USE_GCS_CACHE_SERVICE", "false")
+
+	client := New("https://api.example.com", "account", "", false)
+	client.OrgID = "org with space"
+	client.ProjectID = "project"
+	client.PipelineID = "pipeline"
+	client.StageID = "stage"
+
+	requestURL, err := url.Parse(client.addRequestParameters("https://api.example.com/cache/intel/upload?accountId=account"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	query := requestURL.Query()
+	if query.Get("backend") != "s3" {
+		t.Errorf("backend = %q, want s3", query.Get("backend"))
+	}
+	if query.Get("orgId") != "org with space" {
+		t.Errorf("orgId = %q, want org with space", query.Get("orgId"))
+	}
+	if query.Get("projectId") != "project" {
+		t.Errorf("projectId = %q, want project", query.Get("projectId"))
+	}
+	if query.Get("pipelineId") != "pipeline" {
+		t.Errorf("pipelineId = %q, want pipeline", query.Get("pipelineId"))
+	}
+	if query.Get("stageId") != "stage" {
+		t.Errorf("stageId = %q, want stage", query.Get("stageId"))
+	}
+
+	emptyContextURL, err := url.Parse(New("https://api.example.com", "account", "", false).addRequestParameters("https://api.example.com/cache/intel/upload?accountId=account"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if emptyContextURL.Query().Get("orgId") != "" || emptyContextURL.Query().Get("projectId") != "" || emptyContextURL.Query().Get("pipelineId") != "" || emptyContextURL.Query().Get("stageId") != "" {
+		t.Errorf("empty context added scope parameters: %s", emptyContextURL.RawQuery)
+	}
+}
+
+func TestCacheServiceRequestsIncludeHarnessContext(t *testing.T) {
+	t.Setenv("HARNESS_CI_USE_GCS_CACHE_SERVICE", "false")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		for key, want := range map[string]string{
+			"orgId":      "org",
+			"projectId":  "project",
+			"pipelineId": "pipeline",
+			"stageId":    "stage",
+			"backend":    "s3",
+		} {
+			if got := query.Get(key); got != want {
+				t.Errorf("%s = %q, want %q", key, got, want)
+			}
+		}
+
+		if strings.Contains(r.URL.Path, "list_entries") {
+			_, _ = w.Write([]byte("[]"))
+			return
+		}
+		_, _ = w.Write([]byte("https://presigned-url.example.com"))
+	}))
+	defer server.Close()
+
+	client := New(server.URL, "account", "token", false)
+	client.OrgID = "org"
+	client.ProjectID = "project"
+	client.PipelineID = "pipeline"
+	client.StageID = "stage"
+	ctx := context.Background()
+
+	if _, err := client.GetUploadURLWithQuery(ctx, "cache-key", url.Values{"uploads": {""}}); err != nil {
+		t.Fatalf("legacy multipart URL request: %v", err)
+	}
+	if _, err := client.GetDownloadURLForType(ctx, "step", "cache-key"); err != nil {
+		t.Fatalf("unified URL request: %v", err)
+	}
+	if _, err := client.GetEntriesList(ctx, "cache-prefix"); err != nil {
+		t.Fatalf("legacy list request: %v", err)
+	}
+	if _, err := client.GetEntriesListForType(ctx, "step", "cache-prefix"); err != nil {
+		t.Fatalf("unified list request: %v", err)
+	}
 }

--- a/main.go
+++ b/main.go
@@ -606,6 +606,26 @@ func main() {
 			Usage:   "cache service base url",
 			EnvVars: []string{"PLUGIN_CACHE_SERVICE_BASE_URL"},
 		},
+		&cli.StringFlag{
+			Name:    "org-id",
+			Usage:   "Harness organization identifier for cache-service request context",
+			EnvVars: []string{"HARNESS_ORG_ID"},
+		},
+		&cli.StringFlag{
+			Name:    "project-id",
+			Usage:   "Harness project identifier for cache-service request context",
+			EnvVars: []string{"HARNESS_PROJECT_ID"},
+		},
+		&cli.StringFlag{
+			Name:    "pipeline-id",
+			Usage:   "Harness pipeline identifier for cache-service request context",
+			EnvVars: []string{"HARNESS_PIPELINE_ID"},
+		},
+		&cli.StringFlag{
+			Name:    "stage-id",
+			Usage:   "Harness stage identifier for cache-service request context",
+			EnvVars: []string{"HARNESS_STAGE_ID"},
+		},
 
 		&cli.Int64Flag{
 			Name:    "multipart.chunk.size",
@@ -790,6 +810,10 @@ func run(c *cli.Context) error {
 			AccountID:              c.String("account-id"),
 			Token:                  c.String("cache-service-token"),
 			ServerBaseURL:          c.String("cache-service-baseurl"),
+			OrgID:                  c.String("org-id"),
+			ProjectID:              c.String("project-id"),
+			PipelineID:             c.String("pipeline-id"),
+			StageID:                c.String("stage-id"),
 			CacheType:              c.String("cache-type"),
 			MultipartChunkSize:     c.Int("multipart.chunk.size"),
 			MultipartMaxUploadSize: c.Int("multipart.max.size"),

--- a/storage/backend/harness/config.go
+++ b/storage/backend/harness/config.go
@@ -5,6 +5,10 @@ type Config struct {
 	AccountID     string
 	Token         string
 	ServerBaseURL string
+	OrgID         string
+	ProjectID     string
+	PipelineID    string
+	StageID       string
 	// CacheType selects unified cache-type aware APIs when non-empty (e.g., "step").
 	CacheType              string
 	MultipartChunkSize     int

--- a/storage/backend/harness/harness.go
+++ b/storage/backend/harness/harness.go
@@ -52,6 +52,10 @@ type Backend struct {
 // New creates an Harness backend.
 func New(l log.Logger, c Config, debug bool) (*Backend, error) {
 	cacheClient := harness.NewWithLogger(c.ServerBaseURL, c.AccountID, c.Token, false, l)
+	cacheClient.OrgID = c.OrgID
+	cacheClient.ProjectID = c.ProjectID
+	cacheClient.PipelineID = c.PipelineID
+	cacheClient.StageID = c.StageID
 	backend := &Backend{
 		logger: l,
 		token:  c.Token,


### PR DESCRIPTION
### Description

- Pass Harness org, project, pipeline, and stage identifiers from plugin environment variables to cache-service requests.
- Add orgId, projectId, pipelineId, and stageId query parameters to legacy Intel and unified cache API calls when values are present.
- Add coverage for encoded values, omitted context, and legacy/unified/list request paths.


### Checklist

<!-- _Please make sure to review and check all of these items:_ -->

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [ ] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [x] Add tests to cover changes.
- [ ] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [ ] Code compiles correctly.
    - [ ] Created tests which fail without the change (if possible).
    - [ ] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [ ] Improve and update the [README](README.md) (if necessary).
- [ ] Ensure [documentation](./DOCS.md) is up-to-date. The same file will be updated in [plugin index](https://github.com/drone/drone-plugin-index/blob/master/content/meltwater/drone-cache/index.md) when your PR is accepted, so it will be available for end-users at http://plugins.drone.io.
