### PR TITLE
fix: [CI-24154]: Avoid corrupting gradle.properties on append

### DIFF
--- a/internal/plugin/autodetect/prepare_gradle.go
+++ b/internal/plugin/autodetect/prepare_gradle.go
@@ -37,6 +37,28 @@ func (*gradlePreparer) PrepareRepo(dir string) (string, error) {
 		return pathToCache, nil
 	}
 
+	// If the file is non-empty and does not end with a newline, prepend one so
+	// appended properties are not concatenated onto the last customer line (CI-24154).
+	info, err := os.Stat(fileName)
+	if err != nil {
+		return "", err
+	}
+	if info.Size() > 0 {
+		f, err := os.Open(fileName)
+		if err != nil {
+			return "", err
+		}
+		buf := make([]byte, 1)
+		_, err = f.ReadAt(buf, info.Size()-1)
+		f.Close()
+		if err != nil {
+			return "", err
+		}
+		if buf[0] != '\n' {
+			cmdToOverrideRepo = "\n" + cmdToOverrideRepo
+		}
+	}
+
 	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644) //nolint:gomnd
 
 	if err != nil {

--- a/internal/plugin/autodetect/prepare_gradle_test.go
+++ b/internal/plugin/autodetect/prepare_gradle_test.go
@@ -1,0 +1,112 @@
+package autodetect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/meltwater/drone-cache/test"
+)
+
+func readGradleProperties(t *testing.T, dir string) string {
+	t.Helper()
+
+	content, err := os.ReadFile(filepath.Join(dir, "gradle.properties"))
+	test.Ok(t, err)
+
+	return string(content)
+}
+
+func assertInjected(t *testing.T, content, pathToCache string) {
+	t.Helper()
+
+	lines := strings.Split(content, "\n")
+	test.Assert(t, contains(lines, "systemProp.gradle.user.home="+pathToCache),
+		"systemProp.gradle.user.home should be on its own line, got %q", content)
+	test.Assert(t, contains(lines, "org.gradle.caching=true"),
+		"org.gradle.caching should be on its own line, got %q", content)
+}
+
+func contains(lines []string, want string) bool {
+	for _, line := range lines {
+		if line == want {
+			return true
+		}
+	}
+
+	return false
+}
+
+func TestGradlePreparerFileWithoutTrailingNewline(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gradle-no-newline-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	// Customer file whose last line has no trailing newline.
+	test.Ok(t, os.WriteFile(filepath.Join(dir, "gradle.properties"),
+		[]byte("org.gradle.jvmargs=-Xmx2g\nrelease.stage=SNAPSHOT"), 0644))
+
+	pathToCache, err := (&gradlePreparer{}).PrepareRepo(dir)
+	test.Ok(t, err)
+	test.Equals(t, filepath.Join(dir, ".gradle"), pathToCache)
+
+	content := readGradleProperties(t, dir)
+
+	test.Assert(t, !strings.Contains(content, "release.stage=SNAPSHOTsystemProp"),
+		"injected property must not be concatenated onto the last customer property, got %q", content)
+	test.Assert(t, contains(strings.Split(content, "\n"), "release.stage=SNAPSHOT"),
+		"existing property must stay intact on its own line, got %q", content)
+	assertInjected(t, content, pathToCache)
+}
+
+func TestGradlePreparerFileWithTrailingNewline(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gradle-newline-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	initial := "release.stage=SNAPSHOT\n"
+	test.Ok(t, os.WriteFile(filepath.Join(dir, "gradle.properties"), []byte(initial), 0644))
+
+	pathToCache, err := (&gradlePreparer{}).PrepareRepo(dir)
+	test.Ok(t, err)
+
+	content := readGradleProperties(t, dir)
+
+	test.Assert(t, strings.HasPrefix(content, initial),
+		"existing content must be preserved verbatim, got %q", content)
+	test.Assert(t, !strings.Contains(content, "\n\n"),
+		"no blank line should be introduced, got %q", content)
+	assertInjected(t, content, pathToCache)
+}
+
+func TestGradlePreparerEmptyFile(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gradle-empty-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	test.Ok(t, os.WriteFile(filepath.Join(dir, "gradle.properties"), []byte(""), 0644))
+
+	pathToCache, err := (&gradlePreparer{}).PrepareRepo(dir)
+	test.Ok(t, err)
+
+	content := readGradleProperties(t, dir)
+
+	test.Assert(t, !strings.HasPrefix(content, "\n"),
+		"empty file should not gain a leading blank line, got %q", content)
+	assertInjected(t, content, pathToCache)
+}
+
+func TestGradlePreparerCreatesMissingFile(t *testing.T) {
+	dir, err := os.MkdirTemp("", "gradle-create-*")
+	test.Ok(t, err)
+	defer os.RemoveAll(dir)
+
+	pathToCache, err := (&gradlePreparer{}).PrepareRepo(dir)
+	test.Ok(t, err)
+
+	content := readGradleProperties(t, dir)
+
+	test.Equals(t, 1, strings.Count(content, "org.gradle.caching=true"))
+	assertInjected(t, content, pathToCache)
+}


### PR DESCRIPTION
Fixes CI-24154

## Proposed Changes

- Ensure a newline exists before appending Cache Intelligence properties to an existing `gradle.properties`
- Add unit tests for no-trailing-newline, trailing-newline, empty, and missing-file cases

### Description

When Cache Intelligence prepares a Gradle repo, it appends these lines to the project `gradle.properties`:

    systemProp.gradle.user.home=<workspace>/.gradle
    org.gradle.caching=true

If that file does not end with a trailing newline, the injected property is concatenated onto the last customer line, for example:

    release.stage=SNAPSHOTsystemProp.gradle.user.home=/harness/.gradle

This corrupts the file and breaks Gradle property parsing.

This change prepends a newline to the injected content when the existing file is non-empty and does not already end with a newline. The create-new-file path is unchanged.

### Validation

- Unit tests: `go test ./internal/plugin/autodetect/ -run Gradle`
- Local pipeline with patched image `siddhuroy/drone-cache:1`: `release.stage=SNAPSHOT` remains on its own line; Gradle succeeds
- Local pipeline with `plugins/cache:1.10.7`: reproduces concatenation / Run step failure

### Screenshots

**Before (`plugins/cache:1.10.7`) — corruption / Run failure**

<img width="3242" height="1908" alt="image" src="https://github.com/user-attachments/assets/2575a28a-fec0-4640-814d-57f050b50b5c" />

**After (`siddhuroy/drone-cache:1`) — properties intact**

<img width="3256" height="1898" alt="image" src="https://github.com/user-attachments/assets/27a08818-8b5e-4e98-8afb-88025a90d0e3" />