### PR TITLE
feat: [CI-24147]: detect npm caching via package-lock.json instead of…

### DIFF
--- a/internal/plugin/autodetect/auto_detect_util.go
+++ b/internal/plugin/autodetect/auto_detect_util.go
@@ -19,6 +19,7 @@ type buildToolInfo struct {
 	// A second file to fold into the cache key. Hashed before globToDetect.
 	additionalHashGlob string
 	usePerProject      bool
+	excludeIfExist     []string
 }
 
 // containsTool checks if a tool is already in the slice
@@ -32,6 +33,16 @@ func containsTool(slice []string, tool string) bool {
 }
 
 func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, error) {
+	return detectDirectoriesToCache(skipPrepare, false)
+}
+
+// DetectDirectoriesToCacheWithNpmPackageJSON replays a package.json fallback
+// selected by an earlier restore step, even if npm generated a lockfile since.
+func DetectDirectoriesToCacheWithNpmPackageJSON(skipPrepare bool) ([]string, []string, string, error) {
+	return detectDirectoriesToCache(skipPrepare, true)
+}
+
+func detectDirectoriesToCache(skipPrepare, forceNpmPackageJSON bool) ([]string, []string, string, error) {
 	var buildToolInfoMapping = []buildToolInfo{
 		{
 			globToDetect: "pom.xml",
@@ -68,6 +79,14 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 			tool:               "node",
 			preparer:           newNodePreparer(),
 			additionalCacheDir: npmCacheDir,
+		},
+		{
+			// Fallback: package.json only. Caches node_modules without writing .npmrc.
+			// Blocked if another package manager's lockfile is present in the directory.
+			globToDetect:   "package.json",
+			tool:           "node",
+			preparer:       newNodeFallbackPreparer(),
+			excludeIfExist: []string{"yarn.lock", "pnpm-lock.yaml", "bun.lock", "bun.lockb"},
 		},
 		{
 			// Yarn repos matched the old package.json glob too, which is what
@@ -141,10 +160,21 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 				hashes += hash
 			}
 		} else {
-			hash, dir, err := hashFileOrNested(supportedTool.globToDetect)
+			if forceNpmPackageJSON && supportedTool.tool == "node" && supportedTool.globToDetect == "package-lock.json" {
+				continue
+			}
+
+			var hash, dir string
+			var err error
+			if len(supportedTool.excludeIfExist) > 0 {
+				hash, dir, err = hashFileOrNestedExcluding(supportedTool.globToDetect, supportedTool.excludeIfExist)
+			} else {
+				hash, dir, err = hashFileOrNested(supportedTool.globToDetect)
+			}
 			if err != nil {
 				return nil, nil, "", err
 			}
+
 			if hash != "" && !skipPrepare {
 				dirToCache, err := supportedTool.preparer.PrepareRepo(dir)
 				if err != nil {
@@ -182,6 +212,22 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 	return directoriesToCache, buildToolsDetected, hashes, nil
 }
 
+// NpmPackageJSONFallbackDetected reports whether normal detection selected
+// package.json because no npm lockfile was present.
+func NpmPackageJSONFallbackDetected() (bool, error) {
+	hash, _, err := hashFileOrNested("package-lock.json")
+	if err != nil || hash != "" {
+		return false, err
+	}
+
+	hash, _, err = hashFileOrNestedExcluding(
+		"package.json",
+		[]string{"yarn.lock", "pnpm-lock.yaml", "bun.lock", "bun.lockb"},
+	)
+
+	return hash != "", err
+}
+
 func appendIfMissing(slice []string, elem string) []string {
 	for _, v := range slice {
 		if v == elem {
@@ -204,6 +250,40 @@ func hashFileOrNested(glob string) (string, string, error) {
 	}
 
 	return hashIfFileExist(filepath.Join("**", glob))
+}
+
+func hashFileOrNestedExcluding(glob string, blockers []string) (string, string, error) {
+	hash, dir, err := hashIfFileExistExcluding(glob, blockers)
+	if err != nil || hash != "" {
+		return hash, dir, err
+	}
+
+	return hashIfFileExistExcluding(filepath.Join("**", glob), blockers)
+}
+
+func hashIfFileExistExcluding(glob string, blockers []string) (string, string, error) {
+	matches, _ := filepath.Glob(glob)
+
+	var eligible []string
+	for _, match := range matches {
+		blocked := false
+		for _, blocker := range blockers {
+			info, err := os.Stat(filepath.Join(filepath.Dir(match), blocker))
+			if err == nil && !info.IsDir() {
+				blocked = true
+				break
+			}
+		}
+		if !blocked {
+			eligible = append(eligible, match)
+		}
+	}
+
+	if len(eligible) == 0 {
+		return "", "", nil
+	}
+
+	return calculateMd5FromFiles(eligible)
 }
 
 func hashIfFileExist(glob string) (string, string, error) {

--- a/internal/plugin/autodetect/auto_detect_util.go
+++ b/internal/plugin/autodetect/auto_detect_util.go
@@ -10,10 +10,15 @@ import (
 )
 
 type buildToolInfo struct {
-	globToDetect  string
-	tool          string
-	preparer      RepoPreparer
-	usePerProject bool
+	globToDetect string
+	tool         string
+	preparer     RepoPreparer
+	// A second directory to cache, resolved from where the detected file lives.
+	// Has to stay inside the workspace, the only shared volume.
+	additionalCacheDir func(dir string) (string, error)
+	// A second file to fold into the cache key. Hashed before globToDetect.
+	additionalHashGlob string
+	usePerProject      bool
 }
 
 // containsTool checks if a tool is already in the slice
@@ -57,14 +62,22 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 			preparer:     newBazelPreparer(),
 		},
 		{
-			globToDetect: "package.json",
-			tool:         "node",
-			preparer:     newNodePreparer(),
+			// The lockfile, not package.json: a dependency bump often lands in
+			// the lockfile alone, and that has to invalidate the cache.
+			globToDetect:       "package-lock.json",
+			tool:               "node",
+			preparer:           newNodePreparer(),
+			additionalCacheDir: npmCacheDir,
 		},
 		{
-			globToDetect: "yarn.lock",
-			tool:         "yarn",
-			preparer:     newYarnPreparer(),
+			// Yarn repos matched the old package.json glob too, which is what
+			// cached node_modules and put package.json in the key. Both kept
+			// here so yarn behaviour is unchanged.
+			globToDetect:       "yarn.lock",
+			tool:               "yarn",
+			preparer:           newYarnPreparer(),
+			additionalCacheDir: nodeModulesDir,
+			additionalHashGlob: "package.json",
 		},
 		{
 			globToDetect: "go.mod",
@@ -128,15 +141,9 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 				hashes += hash
 			}
 		} else {
-			hash, dir, err := hashIfFileExist(supportedTool.globToDetect)
+			hash, dir, err := hashFileOrNested(supportedTool.globToDetect)
 			if err != nil {
 				return nil, nil, "", err
-			}
-			if hash == "" {
-				hash, dir, err = hashIfFileExist(filepath.Join("**", supportedTool.globToDetect))
-				if err != nil {
-					return nil, nil, "", err
-				}
 			}
 			if hash != "" && !skipPrepare {
 				dirToCache, err := supportedTool.preparer.PrepareRepo(dir)
@@ -145,7 +152,28 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 				}
 
 				directoriesToCache = appendIfMissing(directoriesToCache, dirToCache)
+				if supportedTool.additionalCacheDir != nil {
+					dirToCache, err = supportedTool.additionalCacheDir(dir)
+					if err != nil {
+						return nil, nil, "", err
+					}
+					// Empty when there is no second directory worth caching,
+					// e.g. npm's cache was never relocated.
+					if dirToCache != "" {
+						directoriesToCache = appendIfMissing(directoriesToCache, dirToCache)
+					}
+				}
 				buildToolsDetected = appendIfMissing(buildToolsDetected, supportedTool.tool)
+
+				if supportedTool.additionalHashGlob != "" {
+					additionalHash, _, err := hashFileOrNested(supportedTool.additionalHashGlob)
+					if err != nil {
+						return nil, nil, "", err
+					}
+
+					hashes += additionalHash
+				}
+
 				hashes += hash
 			}
 		}
@@ -161,6 +189,21 @@ func appendIfMissing(slice []string, elem string) []string {
 		}
 	}
 	return append(slice, elem)
+}
+
+// hashFileOrNested hashes the root-most match, falling back to one level down.
+// filepath.Glob does not treat ** as recursive, so it goes no deeper than that.
+func hashFileOrNested(glob string) (string, string, error) {
+	hash, dir, err := hashIfFileExist(glob)
+	if err != nil {
+		return "", "", err
+	}
+
+	if hash != "" {
+		return hash, dir, nil
+	}
+
+	return hashIfFileExist(filepath.Join("**", glob))
 }
 
 func hashIfFileExist(glob string) (string, string, error) {

--- a/internal/plugin/autodetect/auto_detect_util.go
+++ b/internal/plugin/autodetect/auto_detect_util.go
@@ -13,13 +13,12 @@ type buildToolInfo struct {
 	globToDetect string
 	tool         string
 	preparer     RepoPreparer
-	// A second directory to cache, resolved from where the detected file lives.
-	// Has to stay inside the workspace, the only shared volume.
-	additionalCacheDir func(dir string) (string, error)
-	// A second file to fold into the cache key. Hashed before globToDetect.
-	additionalHashGlob string
-	usePerProject      bool
-	excludeIfExist     []string
+	// additionalCacheDirs resolves extra directories to cache for this tool.
+	// Can be removed in the future by updating RepoPreparer.PrepareRepo to return []string.
+	additionalCacheDirs func(dir string) ([]string, error)
+	additionalHashGlob  string
+	usePerProject       bool
+	excludeIfExist      []string
 }
 
 // containsTool checks if a tool is already in the slice
@@ -36,8 +35,7 @@ func DetectDirectoriesToCache(skipPrepare bool) ([]string, []string, string, err
 	return detectDirectoriesToCache(skipPrepare, false)
 }
 
-// DetectDirectoriesToCacheWithNpmPackageJSON replays a package.json fallback
-// selected by an earlier restore step, even if npm generated a lockfile since.
+// DetectDirectoriesToCacheWithNpmPackageJSON forces package.json fallback detection for the save step.
 func DetectDirectoriesToCacheWithNpmPackageJSON(skipPrepare bool) ([]string, []string, string, error) {
 	return detectDirectoriesToCache(skipPrepare, true)
 }
@@ -59,9 +57,6 @@ func detectDirectoriesToCache(skipPrepare, forceNpmPackageJSON bool) ([]string, 
 			tool:         "gradle",
 			preparer:     newGradlePreparer(),
 		},
-		// MODULE.bazel is checked BEFORE WORKSPACE because:
-		// 1. In modern Bazel (6+), MODULE.bazel takes precedence
-		// 2. We only want ONE Bazel preparer to run, not both
 		{
 			globToDetect: "MODULE.bazel",
 			tool:         "bazel",
@@ -73,30 +68,23 @@ func detectDirectoriesToCache(skipPrepare, forceNpmPackageJSON bool) ([]string, 
 			preparer:     newBazelPreparer(),
 		},
 		{
-			// The lockfile, not package.json: a dependency bump often lands in
-			// the lockfile alone, and that has to invalidate the cache.
-			globToDetect:       "package-lock.json",
-			tool:               "node",
-			preparer:           newNodePreparer(),
-			additionalCacheDir: npmCacheDir,
+			globToDetect:        "package-lock.json",
+			tool:                "node",
+			preparer:            newNodePreparer(),
+			additionalCacheDirs: npmCacheDirs,
 		},
 		{
-			// Fallback: package.json only. Caches node_modules without writing .npmrc.
-			// Blocked if another package manager's lockfile is present in the directory.
 			globToDetect:   "package.json",
 			tool:           "node",
 			preparer:       newNodeFallbackPreparer(),
 			excludeIfExist: []string{"yarn.lock", "pnpm-lock.yaml", "bun.lock", "bun.lockb"},
 		},
 		{
-			// Yarn repos matched the old package.json glob too, which is what
-			// cached node_modules and put package.json in the key. Both kept
-			// here so yarn behaviour is unchanged.
-			globToDetect:       "yarn.lock",
-			tool:               "yarn",
-			preparer:           newYarnPreparer(),
-			additionalCacheDir: nodeModulesDir,
-			additionalHashGlob: "package.json",
+			globToDetect:        "yarn.lock",
+			tool:                "yarn",
+			preparer:            newYarnPreparer(),
+			additionalCacheDirs: nodeModulesDirs,
+			additionalHashGlob:  "package.json",
 		},
 		{
 			globToDetect: "go.mod",
@@ -182,15 +170,15 @@ func detectDirectoriesToCache(skipPrepare, forceNpmPackageJSON bool) ([]string, 
 				}
 
 				directoriesToCache = appendIfMissing(directoriesToCache, dirToCache)
-				if supportedTool.additionalCacheDir != nil {
-					dirToCache, err = supportedTool.additionalCacheDir(dir)
+				if supportedTool.additionalCacheDirs != nil {
+					extraDirs, err := supportedTool.additionalCacheDirs(dir)
 					if err != nil {
 						return nil, nil, "", err
 					}
-					// Empty when there is no second directory worth caching,
-					// e.g. npm's cache was never relocated.
-					if dirToCache != "" {
-						directoriesToCache = appendIfMissing(directoriesToCache, dirToCache)
+					for _, extra := range extraDirs {
+						if extra != "" {
+							directoriesToCache = appendIfMissing(directoriesToCache, extra)
+						}
 					}
 				}
 				buildToolsDetected = appendIfMissing(buildToolsDetected, supportedTool.tool)
@@ -212,8 +200,7 @@ func detectDirectoriesToCache(skipPrepare, forceNpmPackageJSON bool) ([]string, 
 	return directoriesToCache, buildToolsDetected, hashes, nil
 }
 
-// NpmPackageJSONFallbackDetected reports whether normal detection selected
-// package.json because no npm lockfile was present.
+// NpmPackageJSONFallbackDetected reports whether package.json was selected as fallback.
 func NpmPackageJSONFallbackDetected() (bool, error) {
 	hash, _, err := hashFileOrNested("package-lock.json")
 	if err != nil || hash != "" {
@@ -237,8 +224,7 @@ func appendIfMissing(slice []string, elem string) []string {
 	return append(slice, elem)
 }
 
-// hashFileOrNested hashes the root-most match, falling back to one level down.
-// filepath.Glob does not treat ** as recursive, so it goes no deeper than that.
+// hashFileOrNested hashes the root match, falling back to one directory level down.
 func hashFileOrNested(glob string) (string, string, error) {
 	hash, dir, err := hashIfFileExist(glob)
 	if err != nil {

--- a/internal/plugin/autodetect/auto_detect_util_test.go
+++ b/internal/plugin/autodetect/auto_detect_util_test.go
@@ -21,6 +21,12 @@ const (
 	toolMavenDir       = ".m2/repository"
 	toolGradle         = "gradle"
 	toolGradleDir      = ".gradle"
+	packageJSONFile    = "package.json"
+	packageLockFile    = "package-lock.json"
+	npmrcFile          = ".npmrc"
+	yarnLockFile       = "yarn.lock"
+	toolNode           = "node"
+	toolYarn           = "yarn"
 )
 
 func TestDetectDirectoriesToCacheMaven(t *testing.T) {
@@ -355,4 +361,276 @@ func TestDetectDirectoriesToCacheDotnetMixedProjectTypes(t *testing.T) {
 	test.Equals(t, directoriesToCache, expectedCacheDir)
 	test.Equals(t, buildToolsDetected, expectedDetectedTool)
 	test.Equals(t, hashes, expectedHash)
+}
+
+// npm exports npm_config_* to child processes, so these are often already set
+// in real shells and CI. Left alone, they would decide the assertions for us.
+func isolateNpmEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("npm_config_cache", "")
+	t.Setenv("NPM_CONFIG_CACHE", "")
+}
+
+func TestDetectDirectoriesToCacheNodeUsesPackageLock(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageLockFile)
+	defer os.Remove(npmrcFile)
+
+	directoriesToCache, buildToolsDetected, hash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	workspace, err := filepath.Abs(".")
+	test.Ok(t, err)
+	// Both have to be inside the workspace, the only shared volume.
+	test.Equals(t, directoriesToCache, []string{
+		filepath.Join(workspace, "node_modules"),
+		filepath.Join(workspace, npmCacheDirName),
+	})
+	test.Equals(t, buildToolsDetected, []string{toolNode})
+	test.Equals(t, hash, "baab6c16d9143523b7865d46896e4596")
+
+	// npm has to be told, or it keeps writing to ~/.npm.
+	npmrc, err := os.ReadFile(npmrcFile)
+	test.Ok(t, err)
+	test.Equals(t, string(npmrc), "cache="+filepath.Join(workspace, npmCacheDirName)+"\n")
+}
+
+func TestDetectDirectoriesToCacheNodeModulesBesideNestedPackageLock(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.MkdirAll(nestedDirectory, 0755))
+	defer os.RemoveAll(nestedDirectory)
+	test.Ok(t, os.WriteFile(filepath.Join(nestedDirectory, packageLockFile), []byte(testFileContent), 0644))
+
+	directoriesToCache, buildToolsDetected, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	nested, err := filepath.Abs(nestedDirectory)
+	test.Ok(t, err)
+	test.Equals(t, directoriesToCache, []string{
+		filepath.Join(nested, "node_modules"),
+		filepath.Join(nested, npmCacheDirName),
+	})
+	test.Equals(t, buildToolsDetected, []string{toolNode})
+	test.Exists(t, filepath.Join(nestedDirectory, npmrcFile))
+}
+
+func TestDetectDirectoriesToCacheNodeIgnoresPackageJSONOnly(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.WriteFile(packageJSONFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageJSONFile)
+
+	directoriesToCache, buildToolsDetected, hash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	test.Assert(t, directoriesToCache == nil, "expected no cache directories, got %v", directoriesToCache)
+	test.Assert(t, buildToolsDetected == nil, "expected no detected tools, got %v", buildToolsDetected)
+	test.Equals(t, hash, "")
+}
+
+func TestDetectDirectoriesToCacheNodeLockfileChangeInvalidatesKey(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageLockFile)
+	defer os.Remove(npmrcFile)
+
+	_, _, firstHash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent2), 0644))
+	_, _, secondHash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	test.Assert(t, firstHash != secondHash, "expected package-lock.json change to invalidate cache key")
+}
+
+// Restore and save both run detection in the same workspace, so the second run
+// has to land on the same path without appending a duplicate entry.
+func TestDetectDirectoriesToCacheNodeIsIdempotentAcrossSteps(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageLockFile)
+	defer os.Remove(npmrcFile)
+
+	firstDirs, _, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+	firstNpmrc, err := os.ReadFile(npmrcFile)
+	test.Ok(t, err)
+
+	secondDirs, _, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+	secondNpmrc, err := os.ReadFile(npmrcFile)
+	test.Ok(t, err)
+
+	test.Equals(t, firstDirs, secondDirs)
+	test.Equals(t, string(firstNpmrc), string(secondNpmrc))
+}
+
+// Appending our own entry would silently move the user's cache, so theirs wins.
+func TestDetectDirectoriesToCacheNodeRespectsExistingNpmrcCache(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageLockFile)
+	test.Ok(t, os.WriteFile(npmrcFile, []byte("registry=https://example.com\ncache=custom-npm-cache\n"), 0644))
+	defer os.Remove(npmrcFile)
+
+	directoriesToCache, _, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	workspace, err := filepath.Abs(".")
+	test.Ok(t, err)
+	test.Equals(t, directoriesToCache, []string{
+		filepath.Join(workspace, "node_modules"),
+		filepath.Join(workspace, "custom-npm-cache"),
+	})
+
+	npmrc, err := os.ReadFile(npmrcFile)
+	test.Ok(t, err)
+	test.Equals(t, string(npmrc), "registry=https://example.com\ncache=custom-npm-cache\n")
+}
+
+// npm_config_cache overrides .npmrc, so the env var path is what gets cached.
+func TestDetectDirectoriesToCacheNodeHonoursNpmConfigCacheEnv(t *testing.T) {
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageLockFile)
+
+	envCache, err := filepath.Abs("env-npm-cache")
+	test.Ok(t, err)
+	t.Setenv("npm_config_cache", envCache)
+
+	directoriesToCache, _, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	workspace, err := filepath.Abs(".")
+	test.Ok(t, err)
+	test.Equals(t, directoriesToCache, []string{filepath.Join(workspace, "node_modules"), envCache})
+
+	_, err = os.Stat(npmrcFile)
+	test.Assert(t, os.IsNotExist(err), "expected no .npmrc to be written when npm_config_cache is set")
+}
+
+// Appending must not run into the last line of a user's file (CI-24154).
+func TestDetectDirectoriesToCacheNodeAppendsToNpmrcWithoutTrailingNewline(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageLockFile)
+	test.Ok(t, os.WriteFile(npmrcFile, []byte("registry=https://example.com"), 0644))
+	defer os.Remove(npmrcFile)
+
+	_, _, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	workspace, err := filepath.Abs(".")
+	test.Ok(t, err)
+	npmrc, err := os.ReadFile(npmrcFile)
+	test.Ok(t, err)
+	test.Equals(t, string(npmrc),
+		"registry=https://example.com\ncache="+filepath.Join(workspace, npmCacheDirName)+"\n")
+}
+
+// .npmrc is sometimes a read-only mounted secret. Losing the tarball cache is
+// fine; failing the whole step is not.
+func TestDetectDirectoriesToCacheNodeSurvivesUnwritableNpmrc(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores file permissions")
+	}
+
+	isolateNpmEnv(t)
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageLockFile)
+	test.Ok(t, os.WriteFile(npmrcFile, []byte("registry=https://example.com\n"), 0444))
+	defer os.Remove(npmrcFile)
+
+	directoriesToCache, buildToolsDetected, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	workspace, err := filepath.Abs(".")
+	test.Ok(t, err)
+	test.Equals(t, directoriesToCache, []string{filepath.Join(workspace, "node_modules")})
+	test.Equals(t, buildToolsDetected, []string{toolNode})
+
+	// Left exactly as it was.
+	npmrc, err := os.ReadFile(npmrcFile)
+	test.Ok(t, err)
+	test.Equals(t, string(npmrc), "registry=https://example.com\n")
+}
+
+// md5Hex is what one file contributes to the cache key.
+func md5Hex(t *testing.T, content string) string {
+	t.Helper()
+
+	h := md5.New() // #nosec
+	_, err := h.Write([]byte(content))
+	test.Ok(t, err)
+
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Yarn repos matched the old package.json glob too, so their key was
+// md5(package.json) then md5(yarn.lock). It has to stay byte-identical, or
+// every yarn repo takes a miss on upgrade.
+func TestDetectDirectoriesToCacheYarnKeyIncludesPackageJSON(t *testing.T) {
+	test.Ok(t, os.WriteFile(packageJSONFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageJSONFile)
+	test.Ok(t, os.WriteFile(yarnLockFile, []byte(testFileContent2), 0644))
+	defer os.Remove(yarnLockFile)
+	defer os.Remove(".yarnrc")
+	defer os.Remove(".yarnrc.yaml")
+
+	_, buildToolsDetected, hash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	test.Equals(t, buildToolsDetected, []string{toolYarn})
+	test.Equals(t, hash, md5Hex(t, testFileContent)+md5Hex(t, testFileContent2))
+}
+
+func TestDetectDirectoriesToCacheYarnKeyChangesWithPackageJSON(t *testing.T) {
+	test.Ok(t, os.WriteFile(packageJSONFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageJSONFile)
+	test.Ok(t, os.WriteFile(yarnLockFile, []byte(testFileContent2), 0644))
+	defer os.Remove(yarnLockFile)
+	defer os.Remove(".yarnrc")
+	defer os.Remove(".yarnrc.yaml")
+
+	_, _, firstHash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	test.Ok(t, os.WriteFile(packageJSONFile, []byte("changed"), 0644))
+	_, _, secondHash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	test.Assert(t, firstHash != secondHash, "expected package.json change to invalidate the yarn cache key")
+}
+
+// No package.json means only yarn.lock contributes, as before - there was
+// nothing for the old glob to match either.
+func TestDetectDirectoriesToCacheYarnKeyWithoutPackageJSON(t *testing.T) {
+	test.Ok(t, os.WriteFile(yarnLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(yarnLockFile)
+	defer os.Remove(".yarnrc")
+	defer os.Remove(".yarnrc.yaml")
+
+	_, _, hash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	test.Equals(t, hash, md5Hex(t, testFileContent))
+}
+
+// The old package.json glob is what cached node_modules for yarn repos.
+func TestDetectDirectoriesToCacheYarnStillCachesNodeModules(t *testing.T) {
+	test.Ok(t, os.WriteFile(yarnLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(yarnLockFile)
+	defer os.Remove(".yarnrc")
+	defer os.Remove(".yarnrc.yaml")
+
+	directoriesToCache, buildToolsDetected, _, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	workspace, err := filepath.Abs(".")
+	test.Ok(t, err)
+	test.Equals(t, directoriesToCache, []string{
+		filepath.Join(workspace, ".yarn"),
+		filepath.Join(workspace, "node_modules"),
+	})
+	test.Equals(t, buildToolsDetected, []string{toolYarn})
 }

--- a/internal/plugin/autodetect/auto_detect_util_test.go
+++ b/internal/plugin/autodetect/auto_detect_util_test.go
@@ -415,7 +415,7 @@ func TestDetectDirectoriesToCacheNodeModulesBesideNestedPackageLock(t *testing.T
 	test.Exists(t, filepath.Join(nestedDirectory, npmrcFile))
 }
 
-func TestDetectDirectoriesToCacheNodeIgnoresPackageJSONOnly(t *testing.T) {
+func TestDetectDirectoriesToCacheNodeFallsBackToPackageJSON(t *testing.T) {
 	isolateNpmEnv(t)
 	test.Ok(t, os.WriteFile(packageJSONFile, []byte(testFileContent), 0644))
 	defer os.Remove(packageJSONFile)
@@ -423,9 +423,79 @@ func TestDetectDirectoriesToCacheNodeIgnoresPackageJSONOnly(t *testing.T) {
 	directoriesToCache, buildToolsDetected, hash, err := DetectDirectoriesToCache(false)
 	test.Ok(t, err)
 
-	test.Assert(t, directoriesToCache == nil, "expected no cache directories, got %v", directoriesToCache)
-	test.Assert(t, buildToolsDetected == nil, "expected no detected tools, got %v", buildToolsDetected)
-	test.Equals(t, hash, "")
+	workspace, err := filepath.Abs(".")
+	test.Ok(t, err)
+	test.Equals(t, directoriesToCache, []string{filepath.Join(workspace, "node_modules")})
+	test.Equals(t, buildToolsDetected, []string{toolNode})
+	test.Equals(t, hash, md5Hex(t, testFileContent))
+
+	_, err = os.Stat(npmrcFile)
+	test.Assert(t, os.IsNotExist(err), "package.json fallback must not write .npmrc")
+}
+
+func TestDetectDirectoriesToCacheNodePrefersPackageLock(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.WriteFile(packageJSONFile, []byte(testFileContent2), 0644))
+	defer os.Remove(packageJSONFile)
+	test.Ok(t, os.WriteFile(packageLockFile, []byte(testFileContent), 0644))
+	defer os.Remove(packageLockFile)
+	defer os.Remove(npmrcFile)
+
+	directoriesToCache, buildToolsDetected, hash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	workspace, err := filepath.Abs(".")
+	test.Ok(t, err)
+	test.Equals(t, directoriesToCache, []string{
+		filepath.Join(workspace, "node_modules"),
+		filepath.Join(workspace, npmCacheDirName),
+	})
+	test.Equals(t, buildToolsDetected, []string{toolNode})
+	test.Equals(t, hash, md5Hex(t, testFileContent))
+}
+
+func TestDetectDirectoriesToCacheNodeModulesBesideNestedPackageJSON(t *testing.T) {
+	isolateNpmEnv(t)
+	test.Ok(t, os.MkdirAll(nestedDirectory, 0755))
+	defer os.RemoveAll(nestedDirectory)
+	test.Ok(t, os.WriteFile(
+		filepath.Join(nestedDirectory, packageJSONFile),
+		[]byte(testFileContent),
+		0644,
+	))
+
+	directoriesToCache, buildToolsDetected, hash, err := DetectDirectoriesToCache(false)
+	test.Ok(t, err)
+
+	nested, err := filepath.Abs(nestedDirectory)
+	test.Ok(t, err)
+	test.Equals(t, directoriesToCache, []string{filepath.Join(nested, "node_modules")})
+	test.Equals(t, buildToolsDetected, []string{toolNode})
+	test.Equals(t, hash, md5Hex(t, testFileContent))
+}
+
+func TestDetectDirectoriesToCacheNodeFallbackIgnoresOtherPackageManagers(t *testing.T) {
+	for _, lockfile := range []string{"yarn.lock", "pnpm-lock.yaml", "bun.lock", "bun.lockb"} {
+		t.Run(lockfile, func(t *testing.T) {
+			isolateNpmEnv(t)
+			dir := t.TempDir()
+			t.Chdir(dir)
+			test.Ok(t, os.WriteFile(packageJSONFile, []byte(testFileContent), 0644))
+			test.Ok(t, os.WriteFile(lockfile, []byte(testFileContent2), 0644))
+
+			directoriesToCache, buildToolsDetected, _, err := DetectDirectoriesToCache(false)
+			test.Ok(t, err)
+
+			if lockfile == yarnLockFile {
+				test.Equals(t, buildToolsDetected, []string{toolYarn})
+				test.Assert(t, len(directoriesToCache) == 2, "expected yarn cache paths")
+				return
+			}
+
+			test.Assert(t, directoriesToCache == nil, "expected no npm cache paths, got %v", directoriesToCache)
+			test.Assert(t, buildToolsDetected == nil, "expected no detected tools, got %v", buildToolsDetected)
+		})
+	}
 }
 
 func TestDetectDirectoriesToCacheNodeLockfileChangeInvalidatesKey(t *testing.T) {

--- a/internal/plugin/autodetect/auto_key.go
+++ b/internal/plugin/autodetect/auto_key.go
@@ -26,8 +26,7 @@ var (
 	ErrPlanScopeMismatch = errors.New("cache plan scope does not match this execution")
 )
 
-// AutoDetectPlan preserves the package.json decision made by Restore.
-// PathIDs are hashes of autodetected paths, never paths trusted for archiving.
+// AutoDetectPlan preserves the fallback plan between restore and save steps.
 type AutoDetectPlan struct {
 	Key     string   `json:"key"`
 	Scope   string   `json:"scope"`

--- a/internal/plugin/autodetect/auto_key.go
+++ b/internal/plugin/autodetect/auto_key.go
@@ -1,0 +1,286 @@
+package autodetect
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	harnessTmpPathEnv = "HARNESS_TMP_PATH"
+	autoPlanDirName   = ".cache-intelligence"
+	autoPlanMaxSize   = 64 * 1024
+	autoPlanMaxKey    = 4096
+	autoHashHexSize   = 32
+)
+
+var (
+	ErrInvalidPlanScope  = errors.New("cache plan scope is incomplete")
+	ErrInvalidPlan       = errors.New("invalid cache plan")
+	ErrPlanScopeMismatch = errors.New("cache plan scope does not match this execution")
+)
+
+// AutoDetectPlan preserves the package.json decision made by Restore.
+// PathIDs are hashes of autodetected paths, never paths trusted for archiving.
+type AutoDetectPlan struct {
+	Key     string   `json:"key"`
+	Scope   string   `json:"scope"`
+	PathIDs []string `json:"path_ids"`
+}
+
+func firstEnv(names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func planScope() (string, error) {
+	execution := firstEnv("HARNESS_EXECUTION_ID", "HARNESS_BUILD_ID", "DRONE_BUILD_NUMBER")
+	stage := firstEnv("HARNESS_STAGE_ID", "DRONE_STAGE_NUMBER", "DRONE_STAGE_NAME")
+	if execution == "" || stage == "" {
+		return "", ErrInvalidPlanScope
+	}
+
+	parts := []string{
+		firstEnv("HARNESS_ACCOUNT_ID"),
+		firstEnv("HARNESS_ORG_ID"),
+		firstEnv("HARNESS_PROJECT_ID"),
+		firstEnv("HARNESS_PIPELINE_ID"),
+		execution,
+		stage,
+		firstEnv("HARNESS_STAGE_INDEX"),
+		firstEnv("HARNESS_NODE_INDEX"),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+
+	return fmt.Sprintf("%x", sum[:]), nil
+}
+
+func autoPlanPath() (string, string, error) {
+	root := strings.TrimSpace(os.Getenv(harnessTmpPathEnv))
+	if root == "" {
+		return "", "", fmt.Errorf("%w: %s is not set", ErrInvalidPlan, harnessTmpPathEnv)
+	}
+	root = filepath.Clean(root)
+	if !filepath.IsAbs(root) {
+		return "", "", fmt.Errorf("%w: %s must be absolute", ErrInvalidPlan, harnessTmpPathEnv)
+	}
+
+	scope, err := planScope()
+	if err != nil {
+		return "", "", err
+	}
+
+	return filepath.Join(root, autoPlanDirName, "drone-cache-autodetect-"+scope+".json"), scope, nil
+}
+
+func validatePlan(plan AutoDetectPlan) error {
+	if len(plan.Key) == 0 || len(plan.Key) > autoPlanMaxKey || len(plan.Key)%autoHashHexSize != 0 {
+		return fmt.Errorf("%w: malformed key", ErrInvalidPlan)
+	}
+	for _, char := range plan.Key {
+		if !strings.ContainsRune("0123456789abcdef", char) {
+			return fmt.Errorf("%w: malformed key", ErrInvalidPlan)
+		}
+	}
+	if len(plan.PathIDs) == 0 || len(plan.PathIDs) > 256 {
+		return fmt.Errorf("%w: malformed path identities", ErrInvalidPlan)
+	}
+	for _, id := range plan.PathIDs {
+		if len(id) != sha256.Size*2 {
+			return fmt.Errorf("%w: malformed path identity", ErrInvalidPlan)
+		}
+		for _, char := range id {
+			if !strings.ContainsRune("0123456789abcdef", char) {
+				return fmt.Errorf("%w: malformed path identity", ErrInvalidPlan)
+			}
+		}
+	}
+
+	return nil
+}
+
+func validatePlanFile(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: plan is not a regular file", ErrInvalidPlan)
+	}
+	if info.Size() > autoPlanMaxSize {
+		return fmt.Errorf("%w: plan is too large", ErrInvalidPlan)
+	}
+
+	return nil
+}
+
+// PathIdentities returns stable hashes for the paths selected by Restore.
+func PathIdentities(paths []string) []string {
+	ids := make([]string, 0, len(paths))
+	for _, path := range paths {
+		sum := sha256.Sum256([]byte(filepath.Clean(path)))
+		ids = append(ids, fmt.Sprintf("%x", sum[:]))
+	}
+	sort.Strings(ids)
+
+	return ids
+}
+
+// FilterPathsForPlan only removes paths; plan contents can never add a path.
+func FilterPathsForPlan(paths, ids []string) []string {
+	allowed := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		allowed[id] = struct{}{}
+	}
+
+	filtered := make([]string, 0, len(paths))
+	for _, path := range paths {
+		sum := sha256.Sum256([]byte(filepath.Clean(path)))
+		if _, ok := allowed[fmt.Sprintf("%x", sum[:])]; ok {
+			filtered = append(filtered, path)
+		}
+	}
+
+	return filtered
+}
+
+// WriteAutoDetectPlan atomically records the current execution's fallback.
+func WriteAutoDetectPlan(plan AutoDetectPlan) error {
+	path, scope, err := autoPlanPath()
+	if err != nil {
+		return err
+	}
+	plan.Scope = scope
+	if err := validatePlan(plan); err != nil {
+		return err
+	}
+
+	data, err := json.Marshal(plan)
+	if err != nil {
+		return err
+	}
+	if len(data) > autoPlanMaxSize {
+		return fmt.Errorf("%w: encoded plan is too large", ErrInvalidPlan)
+	}
+
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	info, err := os.Lstat(dir)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("%w: plan directory is not a regular directory", ErrInvalidPlan)
+	}
+	if err := os.Chmod(dir, 0700); err != nil {
+		return err
+	}
+
+	if err := validatePlanFile(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+
+	file, err := os.CreateTemp(dir, ".drone-cache-plan-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := file.Name()
+	defer os.Remove(tmpPath)
+
+	if err := file.Chmod(0600); err != nil {
+		file.Close()
+		return err
+	}
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, path)
+}
+
+// ReadAutoDetectPlan returns the fallback recorded for this execution.
+func ReadAutoDetectPlan() (AutoDetectPlan, bool, error) {
+	path, scope, err := autoPlanPath()
+	if err != nil {
+		return AutoDetectPlan{}, false, err
+	}
+	if err := validatePlanFile(path); err != nil {
+		if os.IsNotExist(err) {
+			return AutoDetectPlan{}, false, nil
+		}
+		return AutoDetectPlan{}, false, err
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return AutoDetectPlan{}, false, err
+	}
+	fileInfo, statErr := file.Stat()
+	pathInfo, lstatErr := os.Lstat(path)
+	if statErr != nil || lstatErr != nil || !fileInfo.Mode().IsRegular() ||
+		!pathInfo.Mode().IsRegular() || !os.SameFile(fileInfo, pathInfo) {
+		file.Close()
+		return AutoDetectPlan{}, false, fmt.Errorf("%w: plan changed while opening", ErrInvalidPlan)
+	}
+	data, readErr := io.ReadAll(io.LimitReader(file, autoPlanMaxSize+1))
+	closeErr := file.Close()
+	if readErr != nil {
+		return AutoDetectPlan{}, false, readErr
+	}
+	if closeErr != nil {
+		return AutoDetectPlan{}, false, closeErr
+	}
+	if len(data) > autoPlanMaxSize {
+		return AutoDetectPlan{}, false, fmt.Errorf("%w: plan is too large", ErrInvalidPlan)
+	}
+
+	var plan AutoDetectPlan
+	decoder := json.NewDecoder(strings.NewReader(string(data)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&plan); err != nil {
+		return AutoDetectPlan{}, false, fmt.Errorf("%w: %v", ErrInvalidPlan, err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return AutoDetectPlan{}, false, fmt.Errorf("%w: trailing data", ErrInvalidPlan)
+	}
+	if err := validatePlan(plan); err != nil {
+		return AutoDetectPlan{}, false, err
+	}
+	if plan.Scope != scope {
+		return AutoDetectPlan{}, false, ErrPlanScopeMismatch
+	}
+
+	return plan, true, nil
+}
+
+// RemoveAutoDetectPlan consumes the current execution's fallback.
+func RemoveAutoDetectPlan() error {
+	path, _, err := autoPlanPath()
+	if err != nil {
+		return err
+	}
+	if err := validatePlanFile(path); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	return os.Remove(path)
+}

--- a/internal/plugin/autodetect/auto_key_test.go
+++ b/internal/plugin/autodetect/auto_key_test.go
@@ -1,0 +1,89 @@
+package autodetect
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/meltwater/drone-cache/test"
+)
+
+func setAutoPlanEnv(t *testing.T, execution, stage string) {
+	t.Helper()
+	t.Setenv("HARNESS_TMP_PATH", t.TempDir())
+	t.Setenv("HARNESS_EXECUTION_ID", execution)
+	t.Setenv("HARNESS_STAGE_ID", stage)
+	t.Setenv("HARNESS_ACCOUNT_ID", "account")
+	t.Setenv("HARNESS_ORG_ID", "org")
+	t.Setenv("HARNESS_PROJECT_ID", "project")
+	t.Setenv("HARNESS_PIPELINE_ID", "pipeline")
+}
+
+func TestAutoDetectPlanRoundTripAndPathFilter(t *testing.T) {
+	setAutoPlanEnv(t, "execution", "stage")
+
+	workspace := t.TempDir()
+	nodeModules := filepath.Join(workspace, "node_modules")
+	npmCache := filepath.Join(workspace, ".npm")
+	plan := AutoDetectPlan{
+		Key:     md5Hex(t, "package"),
+		PathIDs: PathIdentities([]string{nodeModules}),
+	}
+	test.Ok(t, WriteAutoDetectPlan(plan))
+
+	stored, found, err := ReadAutoDetectPlan()
+	test.Ok(t, err)
+	test.Assert(t, found, "expected plan")
+	test.Equals(t, stored.Key, plan.Key)
+	test.Equals(t, FilterPathsForPlan([]string{nodeModules, npmCache}, stored.PathIDs), []string{nodeModules})
+
+	test.Ok(t, RemoveAutoDetectPlan())
+	_, found, err = ReadAutoDetectPlan()
+	test.Ok(t, err)
+	test.Assert(t, !found, "expected plan to be removed")
+}
+
+func TestAutoDetectPlanIsScopedToExecution(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HARNESS_TMP_PATH", tmp)
+	t.Setenv("HARNESS_STAGE_ID", "stage")
+	t.Setenv("HARNESS_EXECUTION_ID", "first")
+
+	plan := AutoDetectPlan{
+		Key:     md5Hex(t, "package"),
+		PathIDs: PathIdentities([]string{filepath.Join(tmp, "node_modules")}),
+	}
+	test.Ok(t, WriteAutoDetectPlan(plan))
+
+	t.Setenv("HARNESS_EXECUTION_ID", "second")
+	_, found, err := ReadAutoDetectPlan()
+	test.Ok(t, err)
+	test.Assert(t, !found, "another execution must not see this plan")
+}
+
+func TestAutoDetectPlanRejectsSymlink(t *testing.T) {
+	setAutoPlanEnv(t, "execution", "stage")
+
+	path, _, err := autoPlanPath()
+	test.Ok(t, err)
+	test.Ok(t, os.MkdirAll(filepath.Dir(path), 0755))
+	target := filepath.Join(t.TempDir(), "target")
+	test.Ok(t, os.WriteFile(target, []byte("{}"), 0600))
+	test.Ok(t, os.Symlink(target, path))
+
+	_, _, err = ReadAutoDetectPlan()
+	test.Assert(t, errors.Is(err, ErrInvalidPlan), "expected invalid plan, got %v", err)
+}
+
+func TestAutoDetectPlanRequiresHarnessTmpPath(t *testing.T) {
+	t.Setenv("HARNESS_TMP_PATH", "")
+	t.Setenv("HARNESS_EXECUTION_ID", "execution")
+	t.Setenv("HARNESS_STAGE_ID", "stage")
+
+	err := WriteAutoDetectPlan(AutoDetectPlan{
+		Key:     md5Hex(t, "package"),
+		PathIDs: PathIdentities([]string{"/workspace/node_modules"}),
+	})
+	test.Assert(t, errors.Is(err, ErrInvalidPlan), "expected invalid plan root, got %v", err)
+}

--- a/internal/plugin/autodetect/prepare_node.go
+++ b/internal/plugin/autodetect/prepare_node.go
@@ -1,6 +1,20 @@
 package autodetect
 
-import "path/filepath"
+import (
+	"bufio"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// npm's tarball cache, moved out of ~/.npm. The plugin runs in its own
+// container, where $HOME is unset and would point at the wrong home anyway.
+// The workspace is the only volume shared with the build step, same reason
+// maven, gradle, yarn and bazel relocate theirs.
+const npmCacheDirName = ".npm"
+
+const npmrcFileName = ".npmrc"
 
 type nodePreparer struct{}
 
@@ -9,5 +23,158 @@ func newNodePreparer() *nodePreparer {
 }
 
 func (*nodePreparer) PrepareRepo(dir string) (string, error) {
+	// Best effort. .npmrc is sometimes a read-only mounted secret, and failing
+	// to write it shouldn't fail the step - we just lose the tarball cache.
+	_ = prepareNpmrc(dir)
+
 	return filepath.Join(dir, "node_modules"), nil
+}
+
+// npmCacheDir reports where npm will actually put its tarball cache, following
+// npm's precedence: npm_config_cache beats .npmrc. An empty path means the
+// cache was never relocated, so there is nothing here worth archiving.
+func npmCacheDir(dir string) (string, error) {
+	if envCache := npmCacheFromEnv(); envCache != "" {
+		absPath, err := filepath.Abs(envCache)
+		if err != nil {
+			return "", err
+		}
+
+		return filepath.Clean(absPath), nil
+	}
+
+	// PrepareRepo ran first, so an entry exists unless .npmrc was unreadable.
+	configured, err := npmCacheFromNpmrc(filepath.Join(dir, npmrcFileName))
+	if err != nil || configured == "" {
+		return "", nil
+	}
+
+	if filepath.IsAbs(configured) {
+		return filepath.Clean(configured), nil
+	}
+
+	return filepath.Join(dir, configured), nil
+}
+
+// nodeModulesDir is for tools that install into node_modules but keep their
+// download cache elsewhere, e.g. yarn.
+func nodeModulesDir(dir string) (string, error) {
+	return filepath.Join(dir, "node_modules"), nil
+}
+
+// prepareNpmrc appends cache=<dir>/.npm to .npmrc. An existing entry wins,
+// whether it is the user's or ours from an earlier step, so restore and save
+// agree on the path and we never append twice. npm_config_cache overrides
+// .npmrc anyway, so nothing is written when it is set.
+func prepareNpmrc(dir string) error {
+	if npmCacheFromEnv() != "" {
+		return nil
+	}
+
+	fileName := filepath.Join(dir, npmrcFileName)
+
+	configured, err := npmCacheFromNpmrc(fileName)
+	if err != nil {
+		return err
+	}
+
+	if configured != "" {
+		return nil
+	}
+
+	cacheEntry := "cache=" + filepath.Join(dir, npmCacheDirName) + "\n"
+
+	info, err := os.Stat(fileName)
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+
+		return os.WriteFile(fileName, []byte(cacheEntry), 0644) //nolint:gomnd
+	}
+
+	// Don't run our entry onto the end of an unterminated last line (CI-24154).
+	if info.Size() > 0 {
+		terminated, err := endsWithNewline(fileName, info.Size())
+		if err != nil {
+			return err
+		}
+
+		if !terminated {
+			cacheEntry = "\n" + cacheEntry
+		}
+	}
+
+	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644) //nolint:gomnd
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = f.WriteString(cacheEntry)
+
+	return err
+}
+
+func npmCacheFromEnv() string {
+	// npm accepts either casing.
+	for _, name := range []string{"npm_config_cache", "NPM_CONFIG_CACHE"} {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value
+		}
+	}
+
+	return ""
+}
+
+// npmCacheFromNpmrc returns the last cache entry in the file, which is the one
+// npm honours. A missing file yields an empty value.
+func npmCacheFromNpmrc(fileName string) (string, error) {
+	f, err := os.Open(fileName)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+
+		return "", err
+	}
+	defer f.Close()
+
+	var value string
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, ";") || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, rest, found := strings.Cut(line, "=")
+		if !found || strings.TrimSpace(key) != "cache" {
+			continue
+		}
+
+		value = strings.Trim(strings.TrimSpace(rest), `"'`)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return value, nil
+}
+
+func endsWithNewline(fileName string, size int64) (bool, error) {
+	f, err := os.Open(fileName)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	buf := make([]byte, 1)
+	if _, err := f.ReadAt(buf, size-1); err != nil {
+		return false, err
+	}
+
+	return buf[0] == '\n', nil
 }

--- a/internal/plugin/autodetect/prepare_node.go
+++ b/internal/plugin/autodetect/prepare_node.go
@@ -30,6 +30,16 @@ func (*nodePreparer) PrepareRepo(dir string) (string, error) {
 	return filepath.Join(dir, "node_modules"), nil
 }
 
+type nodeFallbackPreparer struct{}
+
+func newNodeFallbackPreparer() *nodeFallbackPreparer {
+	return &nodeFallbackPreparer{}
+}
+
+func (*nodeFallbackPreparer) PrepareRepo(dir string) (string, error) {
+	return filepath.Join(dir, "node_modules"), nil
+}
+
 // npmCacheDir reports where npm will actually put its tarball cache, following
 // npm's precedence: npm_config_cache beats .npmrc. An empty path means the
 // cache was never relocated, so there is nothing here worth archiving.

--- a/internal/plugin/autodetect/prepare_node.go
+++ b/internal/plugin/autodetect/prepare_node.go
@@ -8,10 +8,7 @@ import (
 	"strings"
 )
 
-// npm's tarball cache, moved out of ~/.npm. The plugin runs in its own
-// container, where $HOME is unset and would point at the wrong home anyway.
-// The workspace is the only volume shared with the build step, same reason
-// maven, gradle, yarn and bazel relocate theirs.
+// npmCacheDirName is the workspace directory for relocated npm tarball cache.
 const npmCacheDirName = ".npm"
 
 const npmrcFileName = ".npmrc"
@@ -23,8 +20,7 @@ func newNodePreparer() *nodePreparer {
 }
 
 func (*nodePreparer) PrepareRepo(dir string) (string, error) {
-	// Best effort. .npmrc is sometimes a read-only mounted secret, and failing
-	// to write it shouldn't fail the step - we just lose the tarball cache.
+	// Best-effort configuration of .npmrc.
 	_ = prepareNpmrc(dir)
 
 	return filepath.Join(dir, "node_modules"), nil
@@ -40,42 +36,35 @@ func (*nodeFallbackPreparer) PrepareRepo(dir string) (string, error) {
 	return filepath.Join(dir, "node_modules"), nil
 }
 
-// npmCacheDir reports where npm will actually put its tarball cache, following
-// npm's precedence: npm_config_cache beats .npmrc. An empty path means the
-// cache was never relocated, so there is nothing here worth archiving.
-func npmCacheDir(dir string) (string, error) {
+// npmCacheDirs resolves the effective npm cache directory.
+func npmCacheDirs(dir string) ([]string, error) {
 	if envCache := npmCacheFromEnv(); envCache != "" {
 		absPath, err := filepath.Abs(envCache)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
-		return filepath.Clean(absPath), nil
+		return []string{filepath.Clean(absPath)}, nil
 	}
 
-	// PrepareRepo ran first, so an entry exists unless .npmrc was unreadable.
 	configured, err := npmCacheFromNpmrc(filepath.Join(dir, npmrcFileName))
 	if err != nil || configured == "" {
-		return "", nil
+		return nil, nil
 	}
 
 	if filepath.IsAbs(configured) {
-		return filepath.Clean(configured), nil
+		return []string{filepath.Clean(configured)}, nil
 	}
 
-	return filepath.Join(dir, configured), nil
+	return []string{filepath.Join(dir, configured)}, nil
 }
 
-// nodeModulesDir is for tools that install into node_modules but keep their
-// download cache elsewhere, e.g. yarn.
-func nodeModulesDir(dir string) (string, error) {
-	return filepath.Join(dir, "node_modules"), nil
+// nodeModulesDirs resolves the node_modules path.
+func nodeModulesDirs(dir string) ([]string, error) {
+	return []string{filepath.Join(dir, "node_modules")}, nil
 }
 
-// prepareNpmrc appends cache=<dir>/.npm to .npmrc. An existing entry wins,
-// whether it is the user's or ours from an earlier step, so restore and save
-// agree on the path and we never append twice. npm_config_cache overrides
-// .npmrc anyway, so nothing is written when it is set.
+// prepareNpmrc appends cache=<dir>/.npm to .npmrc if not already configured.
 func prepareNpmrc(dir string) error {
 	if npmCacheFromEnv() != "" {
 		return nil
@@ -137,8 +126,7 @@ func npmCacheFromEnv() string {
 	return ""
 }
 
-// npmCacheFromNpmrc returns the last cache entry in the file, which is the one
-// npm honours. A missing file yields an empty value.
+// npmCacheFromNpmrc returns the cache entry from .npmrc.
 func npmCacheFromNpmrc(fileName string) (string, error) {
 	f, err := os.Open(fileName)
 	if err != nil {

--- a/internal/plugin/autokey_test.go
+++ b/internal/plugin/autokey_test.go
@@ -1,0 +1,111 @@
+package plugin
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-kit/log"
+
+	"github.com/meltwater/drone-cache/archive"
+	"github.com/meltwater/drone-cache/internal/metadata"
+	"github.com/meltwater/drone-cache/internal/plugin/autodetect"
+	"github.com/meltwater/drone-cache/storage/backend"
+	"github.com/meltwater/drone-cache/storage/backend/filesystem"
+	"github.com/meltwater/drone-cache/test"
+)
+
+func TestExecPackageJSONFallbackSurvivesGeneratedLockfile(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("npm_config_cache", "")
+	t.Setenv("NPM_CONFIG_CACHE", "")
+	t.Setenv("HARNESS_TMP_PATH", t.TempDir())
+	setPluginPlanScope(t, "execution-1")
+
+	packageJSON := `{"name":"app","version":"1.0.0"}`
+	test.Ok(t, os.WriteFile("package.json", []byte(packageJSON), 0644))
+
+	cacheRoot := t.TempDir()
+
+	// Build 1 restore is cold, but records the package.json decision.
+	_ = autoDetectPlugin(t, cacheRoot, true, false).Exec()
+	plan, found, err := autodetect.ReadAutoDetectPlan()
+	test.Ok(t, err)
+	test.Assert(t, found, "restore should record a package.json fallback plan")
+
+	// npm install generates a lockfile and node_modules after Restore.
+	test.Ok(t, os.WriteFile("package-lock.json", []byte("generated-lock"), 0644))
+	test.Ok(t, os.MkdirAll("node_modules", 0755))
+	test.Ok(t, os.WriteFile(filepath.Join("node_modules", "index.js"), []byte("cached"), 0644))
+
+	test.Ok(t, autoDetectPlugin(t, cacheRoot, false, true).Exec())
+
+	_, found, err = autodetect.ReadAutoDetectPlan()
+	test.Ok(t, err)
+	test.Assert(t, !found, "successful save should consume the fallback plan")
+	_, err = os.Stat(".npmrc")
+	test.Assert(t, os.IsNotExist(err), "fallback save must not prepare the npm tarball cache")
+	_, err = os.Stat(".npm")
+	test.Assert(t, os.IsNotExist(err), "fallback save must only cache node_modules")
+
+	// Build 2 starts from the same clean package.json-only checkout.
+	test.Ok(t, os.Remove("package-lock.json"))
+	test.Ok(t, os.RemoveAll("node_modules"))
+	setPluginPlanScope(t, "execution-2")
+
+	test.Ok(t, autoDetectPlugin(t, cacheRoot, true, false).Exec())
+	restored, err := os.ReadFile(filepath.Join("node_modules", "index.js"))
+	test.Ok(t, err)
+	test.Equals(t, "cached", string(restored))
+	test.Assert(t, plan.Key != "", "expected a package.json-derived cache key")
+}
+
+func TestExecLockfileSaveDoesNotRequireFallbackPlan(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("npm_config_cache", "")
+	t.Setenv("NPM_CONFIG_CACHE", "")
+	t.Setenv("HARNESS_TMP_PATH", t.TempDir())
+	setPluginPlanScope(t, "execution")
+
+	test.Ok(t, os.WriteFile("package.json", []byte(`{"name":"app"}`), 0644))
+	test.Ok(t, os.WriteFile("package-lock.json", []byte("lock"), 0644))
+	test.Ok(t, os.MkdirAll("node_modules", 0755))
+	test.Ok(t, os.WriteFile(filepath.Join("node_modules", "index.js"), []byte("cached"), 0644))
+
+	test.Ok(t, autoDetectPlugin(t, t.TempDir(), false, true).Exec())
+}
+
+func setPluginPlanScope(t *testing.T, execution string) {
+	t.Helper()
+	t.Setenv("HARNESS_EXECUTION_ID", execution)
+	t.Setenv("HARNESS_STAGE_ID", "stage")
+	t.Setenv("HARNESS_ACCOUNT_ID", "account")
+	t.Setenv("HARNESS_ORG_ID", "org")
+	t.Setenv("HARNESS_PROJECT_ID", "project")
+	t.Setenv("HARNESS_PIPELINE_ID", "pipeline")
+}
+
+func autoDetectPlugin(t *testing.T, cacheRoot string, restore, rebuild bool) *Plugin {
+	t.Helper()
+
+	return &Plugin{
+		logger: log.NewNopLogger(),
+		Metadata: metadata.Metadata{
+			Repo:   metadata.Repo{Branch: "master", Name: "drone-cache"},
+			Commit: metadata.Commit{Branch: "master"},
+		},
+		Config: Config{
+			ArchiveFormat:           archive.Tar,
+			Backend:                 backend.FileSystem,
+			AccountID:               "account",
+			Rebuild:                 rebuild,
+			Restore:                 restore,
+			AutoDetect:              true,
+			Override:                true,
+			CompressionLevel:        archive.DefaultCompressionLevel,
+			StorageOperationTimeout: 5 * time.Second,
+			FileSystem:              filesystem.Config{CacheRoot: cacheRoot},
+		},
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -87,13 +87,41 @@ func (p *Plugin) Exec() error { // nolint:funlen
 	// }
 
 	var generator key.Generator
+	var fallbackPlanUsed bool
 
 	switch {
 	case cfg.AutoDetect:
 		{
-			var toolDetected, keyOverriden bool = false, false
+			var toolDetected bool
 			pathOverridden := len(p.Config.Mount) > 0
-			dirs, buildTools, cacheKey, err := autodetect.DetectDirectoriesToCache(pathOverridden)
+			keyOverriden := cfg.CacheKeyTemplate != ""
+
+			var fallbackPlan autodetect.AutoDetectPlan
+			var fallbackPlanFound bool
+			if cfg.Rebuild && !pathOverridden && !keyOverriden &&
+				strings.TrimSpace(os.Getenv("HARNESS_TMP_PATH")) != "" {
+				var err error
+				fallbackPlan, fallbackPlanFound, err = autodetect.ReadAutoDetectPlan()
+				if err != nil {
+					level.Warn(p.logger).Log(
+						"msg", "could not read package.json cache plan; using current workspace state",
+						"err", err,
+					)
+					_ = autodetect.RemoveAutoDetectPlan()
+					fallbackPlanFound = false
+				}
+			}
+
+			var dirs, buildTools []string
+			var cacheKey string
+			var err error
+			if fallbackPlanFound {
+				dirs, buildTools, cacheKey, err =
+					autodetect.DetectDirectoriesToCacheWithNpmPackageJSON(pathOverridden)
+			} else {
+				dirs, buildTools, cacheKey, err =
+					autodetect.DetectDirectoriesToCache(pathOverridden)
+			}
 			if err != nil {
 				return fmt.Errorf("autodetect enabled but failed to detect, falling back to default, %w", err)
 			}
@@ -105,17 +133,45 @@ func (p *Plugin) Exec() error { // nolint:funlen
 			} else {
 				p.logger.Log("msg", "no supported build tool detected") //nolint: errcheck
 			}
+			if cfg.CacheKeyTemplate != "" {
+				cacheKey = cfg.CacheKeyTemplate
+			} else if cacheKey == "" {
+				cacheKey = "default"
+			}
+
+			if !keyOverriden && !pathOverridden {
+				if cfg.Restore && toolDetected {
+					fallbackDetected, err := autodetect.NpmPackageJSONFallbackDetected()
+					if err != nil {
+						return fmt.Errorf("identify package.json cache fallback, %w", err)
+					}
+					if fallbackDetected {
+						plan := autodetect.AutoDetectPlan{
+							Key:     cacheKey,
+							PathIDs: autodetect.PathIdentities(dirs),
+						}
+						if err := autodetect.WriteAutoDetectPlan(plan); err != nil {
+							level.Warn(p.logger).Log(
+								"msg", "could not record package.json cache plan",
+								"err", err,
+							)
+						}
+					}
+				}
+
+				if cfg.Rebuild && fallbackPlanFound {
+					cacheKey = fallbackPlan.Key
+					dirs = autodetect.FilterPathsForPlan(dirs, fallbackPlan.PathIDs)
+					toolDetected = true
+					fallbackPlanUsed = true
+				}
+			}
+
 			if !pathOverridden {
 				p.Config.Mount = dirs
 				options = append(options, cache.WithGracefulDetect(true))
 			} else {
 				options = append(options, cache.WithGracefulDetect(false))
-			}
-			if cfg.CacheKeyTemplate != "" {
-				keyOverriden = true
-				cacheKey = cfg.CacheKeyTemplate
-			} else if cacheKey == "" {
-				cacheKey = "default"
 			}
 
 			/*
@@ -211,6 +267,11 @@ func (p *Plugin) Exec() error { // nolint:funlen
 		if err := c.Rebuild(p.Config.Mount); err != nil {
 			level.Debug(p.logger).Log("err", fmt.Sprintf("%+v\n", err))
 			return Error(fmt.Sprintf("[IMPORTANT] build cache, %+v\n", err))
+		}
+		if fallbackPlanUsed {
+			if err := autodetect.RemoveAutoDetectPlan(); err != nil {
+				level.Warn(p.logger).Log("msg", "could not remove consumed package.json cache plan", "err", err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes CI-24147

## Proposed Changes

- Detect npm caching from `package-lock.json`, so a lockfile-only dependency bump invalidates the cache
- If there is no lockfile, fall back to `package.json` and cache only `node_modules` (no `.npmrc` / `.npm`)
- Yarn, pnpm, and bun lockfiles block that fallback so those projects are not treated as npm
- Keep Restore and Save on the same key if `npm install` later creates a lockfile
- Move npm’s tarball cache into the workspace (`.npm`) via `.npmrc`, and do not overwrite an existing `cache=` setting or `npm_config_cache` / `NPM_CONFIG_CACHE`
- Leave Yarn unchanged: still hash `package.json` + `yarn.lock`, still cache `node_modules`

### Description

npm cache keys used to follow `package.json`, so a lockfile-only bump could restore a stale cache. Detection now prefers `package-lock.json`. Repos with only `package.json` still get `node_modules` caching. Yarn/pnpm/bun repos stay on their own lockfiles.

### Checklist

- [x] Read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] Read the [**CODE OF CONDUCT**](/CODE_OF_CONDUCT.md) document.
- [x] Add tests to cover changes.
- [x] Ensure your code follows the code style of this project.
- [ ] Ensure CI and all other PR checks are green OR
    - [x] Code compiles correctly.
    - [x] Created tests which fail without the change (if possible).
    - [x] All new and existing tests passed.
- [ ] Add your changes to `Unreleased` section of [CHANGELOG](/CHANGELOG.md).
- [ ] Improve and update the [README](/README.md) (if necessary).
- [ ] Ensure [documentation](/DOCS.md) is up-to-date.